### PR TITLE
fix: cached accessory loss on Skipped, listener leak, inventory retry

### DIFF
--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -104,6 +104,10 @@ export class PicoRemote {
   private trackers: Map<string, ButtonTracker> = new Map()
   // Map button href to ButtonNumber for event lookup
   private hrefToButtonNumber: Map<string, number> = new Map()
+  // Buttons collected during initialize() so a single 'disconnected' handler
+  // can re-subscribe all of them (LeapClient._empty() drops subscriptions on
+  // socket close — unlike pylutron-caseta, which preserves them).
+  private buttons: ButtonDefinition[] = []
 
   private matterApi?: any
   constructor(
@@ -158,11 +162,21 @@ export class PicoRemote {
       }
     }
 
-    bgs.forEach((bg) => {
+    // Bail out if the bridge returned an ExceptionDetail for any button group
+    // (typically when the device is mid-removal in the Lutron app). The previous
+    // code used forEach with `return new Error(...)` — both the return and the
+    // constructed-but-not-thrown Error were no-ops, so ExceptionDetail objects
+    // flowed into getButtonsFromGroup() below and surfaced as opaque errors.
+    // Returning Error here (not Skipped) means the cached accessory is preserved
+    // by the platform.ts cache-preservation rule until the user removes it.
+    for (const bg of bgs) {
       if (bg instanceof ExceptionDetail) {
-        return new Error('Device has been removed')
+        return {
+          kind: DeviceWireResultType.Error,
+          reason: `Bridge returned ExceptionDetail for button group on ${fullName}: ${bg.Message}`,
+        }
       }
-    })
+    }
 
     let buttons: ButtonDefinition[] = []
     for (const bg of bgs) {
@@ -294,15 +308,26 @@ export class PicoRemote {
         ),
       )
 
+      // Track this button so the single 'disconnected' handler registered after
+      // the loop can re-subscribe all of them. The previous code registered one
+      // disconnect listener per button, which leaked listeners (one Pico with N
+      // buttons added N listeners) — that's why platform.ts has setMaxListeners(400).
+      this.buttons.push(button)
       this.platform.log.debug(`subscribing to ${button.href} events`)
       this.bridge.subscribeToButton(button, this.handleEvent.bind(this))
-
-      // when the connection is lost, so are subscriptions.
-      this.bridge.on('disconnected', () => {
-        this.platform.log.debug(`re-subscribing to ${button.href} events after connection loss`)
-        this.bridge.subscribeToButton(button, this.handleEvent.bind(this))
-      })
     }
+
+    // LeapClient._empty() clears all taggedSubscriptions on socket close, so we
+    // must re-register them on reconnect. Home Assistant's lutron_caseta has no
+    // equivalent because pylutron-caseta preserves subscriptions across reconnect;
+    // that asymmetry is worth filing upstream against lutron-leap-js.
+    // One handler per device, not per button — see comment on this.buttons above.
+    this.bridge.on('disconnected', () => {
+      this.platform.log.debug(`re-subscribing to ${this.buttons.length} button(s) after connection loss`)
+      for (const button of this.buttons) {
+        this.bridge.subscribeToButton(button, this.handleEvent.bind(this))
+      }
+    })
 
     this.platform.on('unsolicited', this.handleUnsolicited.bind(this))
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -235,8 +235,34 @@ export class LutronCasetaLeap
     }
   }
 
+  // Wrap getDeviceInfo() with bounded exponential backoff. The plain bridge call
+  // gives up after one failure, leaving the plugin degraded until mDNS re-announce
+  // or a deviceheard event — fragile during bridge firmware updates and brief
+  // network blips. Home Assistant's lutron_caseta delegates retry to Core's
+  // config-entry harness; Homebridge has no equivalent, so we loop in-plugin.
+  // ~65s total budget is comparable to HA's ~59s single-attempt window
+  // (CONNECT_TIMEOUT 9s + CONFIGURE_TIMEOUT 50s).
+  private async getDeviceInfoWithRetry(bridge: SmartBridge): Promise<DeviceDefinition[]> {
+    const delaysMs = [5_000, 15_000, 45_000] // 4 attempts total: immediate, +5s, +15s, +45s
+    let lastError: unknown
+    for (let attempt = 0; attempt <= delaysMs.length; attempt++) {
+      if (attempt > 0) {
+        const delay = delaysMs[attempt - 1]
+        this.log.info(`Retrying device inventory fetch in ${delay / 1000}s (attempt ${attempt + 1}/${delaysMs.length + 1})`)
+        await new Promise(resolve => setTimeout(resolve, delay))
+      }
+      try {
+        return await bridge.getDeviceInfo()
+      } catch (error) {
+        lastError = error
+        this.log.warn(`Device inventory fetch failed (attempt ${attempt + 1}/${delaysMs.length + 1}):`, error)
+      }
+    }
+    throw lastError
+  }
+
   private processAllDevices(bridge: SmartBridge) {
-    bridge.getDeviceInfo().then(async (devices: DeviceDefinition[]) => {
+    this.getDeviceInfoWithRetry(bridge).then(async (devices: DeviceDefinition[]) => {
       const results: PromiseSettledResult<string>[] = await Promise.allSettled(
         devices.map((device: DeviceDefinition) => this.processDevice(bridge, device)),
       )
@@ -253,7 +279,9 @@ export class LutronCasetaLeap
         }
       }
     }).catch((error) => {
-      this.log.warn('Failed to fetch device inventory; skipping this scan:', error)
+      // Log at error (not warn) so users see when the plugin has given up — they
+      // may need to restart Homebridge if the bridge does not recover on its own.
+      this.log.error('Failed to fetch device inventory after retries; skipping this scan. Restart Homebridge if the bridge does not recover on its own:', error)
     })
 
     bridge.on('unsolicited', this.handleUnsolicitedMessage.bind(this))
@@ -283,9 +311,17 @@ export class LutronCasetaLeap
         return Promise.reject(new Error(`Failed to wire device ${fullName}: ${result.reason}`))
       }
       case DeviceWireResultType.Skipped: {
+        // Mirror the Error-path fix from #207 (v3.0.4): never unregister a cached
+        // accessory on a refresh-time classification miss. Skipped fires for transient
+        // bridge responses missing AffectedZones (filterPico path) and for filter
+        // toggles, both of which can flip across runs. Leaving the accessory registered
+        // matches Home Assistant's lutron_caseta philosophy — bridge inventory, not
+        // refresh state, is the source of truth for removal. Users still delete
+        // intentionally-filtered devices via the cached-accessory cleanup documented
+        // in the README.
         if (is_from_cache) {
-          this.log.debug(`un-registered cached device ${fullName} because it was skipped`)
-          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
+          this.log.warn(`Skipping cached device ${fullName}; leaving accessory registered: ${result.reason}`)
+          return Promise.resolve(`Leaving cached accessory registered (skipped): ${fullName}`)
         }
         return Promise.resolve(`Skipped setting up device: ${result.reason}`)
       }


### PR DESCRIPTION
## Summary

Four fixes addressing remaining cached-accessory loss paths and a reliability gap, following #207 (Error path) and #225. Each change is benchmarked against Home Assistant's `lutron_caseta` integration (same LEAP protocol via pylutron-caseta).

- **`Skipped` on a cached accessory no longer unregisters it.** Mirrors the Error-path fix from #207. `Skipped` fires for transient bridge responses missing `AffectedZones` (filterPico path) and for filter toggles, both of which can flip across runs — same blast radius as the original bug, different trigger. Bridge inventory, not refresh state, is the source of truth for removal.
- **`PicoRemote.initialize` ExceptionDetail check is no longer dead code.** The previous `bgs.forEach((bg) => { if (bg instanceof ExceptionDetail) return new Error(...) })` was a no-op (`return` in `forEach` doesn't propagate; `new Error()` without `throw` is discarded). `ExceptionDetail` objects flowed into `getButtonsFromGroup()` and surfaced as opaque errors. Replaced with a `for...of` returning `DeviceWireResultType.Error` carrying the bridge's exception message.
- **Single `disconnected` re-subscribe handler per device, not per button.** The previous code registered `bridge.on('disconnected', ...)` inside the per-button loop, leaking N listeners per N-button Pico (and across refreshes). This is why `setMaxListeners(400)` exists. Now one handler per device that re-subscribes all collected buttons. Note: HA's `lutron_caseta` has no equivalent because pylutron-caseta preserves subscriptions across reconnect; lutron-leap-js's `LeapClient._empty()` clears them on socket close. Filing that asymmetry upstream is worthwhile follow-up.
- **Bounded retry/backoff for `bridge.getDeviceInfo()`.** Single-attempt fetches left the plugin degraded until mDNS re-announce or a `deviceheard` event — fragile during bridge firmware updates and brief network blips. 4 attempts over ~65s, comparable to HA's ~59s window (`CONNECT_TIMEOUT` 9s + `CONFIGURE_TIMEOUT` 50s). Final failure logs at error (not warn) so users see when a manual restart is needed.

Each change carries an inline `// ...` comment explaining the rationale and reference-implementation comparison, since reviewers won't have the benchmark context.

## Out of scope (deliberately left for follow-ups)

- Inventory-vs-cache reconciliation to replace the README's manual-deletion guidance (HA does this via `async_remove_config_entry_device`).
- Mechanical extract of `PicoRemote.initialize()` (~195 lines, mixed concerns) into focused helpers.
- Multi-refresh listener stacking — each `processAllDevices` run constructs a new `PicoRemote` whose disconnect listener is never deregistered. Pre-existing; this PR makes it strictly less leaky (1-per-refresh vs N-per-refresh) but doesn't fix the underlying stack.
- The "SIDE EFFECT: this constructor mutates the accessory" pattern in `wireAccessory` (touches every device class).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Sideloaded onto Homebridge running in HAOS against a real Lutron bridge with 11 Picos (10× Pico2Button, 1× Pico3Button); confirmed:
  - All Picos discovered without errors
  - Zero `un-registered` log lines across multiple restarts (the original bug symptom)
  - No new errors or warnings introduced
- [ ] Recommended for reviewers: trigger the retry path by briefly disconnecting the Lutron bridge from the network; should see `Retrying device inventory fetch in 5s` followed by recovery.
- [ ] Recommended for reviewers: verify the listener-leak fix with `bridge.eventNames()` or by watching for the `MaxListenersExceededWarning` on a many-button-remote setup.