### PR TITLE
feat: configurable log verbosity (logLevel + buttonPressLogging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ This lets you set the speed with which you must click buttons in order to trigge
 
 These features can also be disabled individually in the settings. This can improve responsiveness to the remaining types of presses. **The configuration options in HomeKit do not change, but the plug-in will ignore disabled press types.**
 
+#### Log Verbosity
+
+Two settings control how chatty the plugin's logs are:
+
+- **Log Verbosity** (`logLevel`): `normal` (default), `quiet`, or `errors-only`. `quiet` suppresses info-level lines (startup banners, retry-attempt notices, etc.) and `errors-only` additionally suppresses warnings, leaving only errors. Homebridge's own global debug toggle is unaffected — if you turn that on, debug output will still flow.
+- **Button Press Logging** (`buttonPressLogging`): `debug` (default), `info`, or `silent`. Button presses are special-cased because they're useful when wiring up automations but are noise the rest of the time. `debug` keeps them out of normal logs (visible only when global debug is enabled); `info` makes them visible in normal logs; `silent` drops them entirely.
+
+The defaults reflect a sane "production posture" — startup and per-device discovery lines are visible at info, but per-event noise (button presses, mDNS re-announcements, blind-position polls) is at debug. Turn things up with `buttonPressLogging: info` for short-term troubleshooting, or down with `logLevel: quiet`/`errors-only` for long-term operation.
+
 ## 🏄 User Information
 
 ### Adding and Removing Devices
@@ -231,7 +240,9 @@ The shape of the configuration is:
     "filterPico": false,
     "filterBlinds": false,
     "clickSpeedLong": "default",
-    "clickSpeedDouble": "default"
+    "clickSpeedDouble": "default",
+    "logLevel": "normal",
+    "buttonPressLogging": "debug"
   },
   "secrets": [
     {

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,28 @@
               { "title": "Medium (default)", "enum": ["medium"] },
               { "title": "Slow", "enum": ["slow"] }
             ]
+          },
+          "logLevel": {
+            "type": "string",
+            "title": "Log Verbosity",
+            "description": "Controls which plugin log levels are emitted. 'Normal' is the default and what most users want — info is reserved for one-time lifecycle events, per-event noise is at debug. 'Quiet' suppresses info; 'Errors only' suppresses info AND warn. Homebridge's global debug toggle is not affected by this setting.",
+            "default": "normal",
+            "oneOf": [
+              { "title": "Normal (default)", "enum": ["normal"] },
+              { "title": "Quiet (suppress info)", "enum": ["quiet"] },
+              { "title": "Errors only (suppress info + warn)", "enum": ["errors-only"] }
+            ]
+          },
+          "buttonPressLogging": {
+            "type": "string",
+            "title": "Button Press Logging",
+            "description": "How verbose to be about button-press events specifically. 'Debug' is the default and means presses are quiet in normal logs (visible only with global Homebridge debug). Use 'Info' if you want to see presses while wiring up automations without enabling global debug. Use 'Silent' to drop them entirely.",
+            "default": "debug",
+            "oneOf": [
+              { "title": "Debug — visible only with global debug (default)", "enum": ["debug"] },
+              { "title": "Info — visible in normal logs", "enum": ["info"] },
+              { "title": "Silent — never logged", "enum": ["silent"] }
+            ]
           }
 
         }
@@ -89,6 +111,24 @@
         }
       ]
 
+    },
+    {
+      "type": "div",
+      "displayFlex": true,
+      "items": [
+        {
+          "key": "options.logLevel",
+          "notitle": false,
+          "type": "string",
+          "flex": "1 1 200px"
+        },
+        {
+          "key": "options.buttonPressLogging",
+          "notitle": false,
+          "type": "string",
+          "flex": "1 1 200px"
+        }
+      ]
     },
     {
       "type": "div",

--- a/src/ButtonState.ts
+++ b/src/ButtonState.ts
@@ -1,5 +1,9 @@
 import type { Logging } from 'homebridge'
 
+import type { ButtonPressLogLevel } from './Logger.js'
+
+import { logButtonPress } from './Logger.js'
+
 enum ButtonState {
   IDLE,
   DOWN,
@@ -78,6 +82,10 @@ export class ButtonTracker {
     clickSpeedDouble = 'default',
     clickSpeedLong = 'default',
     isUpDownButton = false,
+    // Default 'debug' matches the platform's optionsFromConfig default —
+    // safe even if a caller (e.g. a future device type or a test) forgets
+    // to thread the option through.
+    private buttonPressLogging: ButtonPressLogLevel = 'debug',
   ) {
     log.debug(`btrk ${this.href} created speed ${clickSpeedDouble} dbl ${clickSpeedLong} long`)
 
@@ -133,14 +141,17 @@ export class ButtonTracker {
         return
       }
 
-      this.log.info(`button ${this.href} got a long press`)
+      // Press lines are routed through logButtonPress() so the user's
+      // 'buttonPressLogging' option (info / debug / silent) governs them
+      // independently of the rest of the plugin's verbosity. See Logger.ts.
+      logButtonPress(this.log, this.buttonPressLogging, `button ${this.href} got a long press`)
       this.longPressCB()
     }
 
     const doublePressTimeoutHandler = () => {
       this.log.debug(`btrk ${this.href} double press expiry`)
       this.reset()
-      this.log.info(`button ${this.href} got a short press`)
+      logButtonPress(this.log, this.buttonPressLogging, `button ${this.href} got a short press`)
       this.shortPressCB()
     }
 
@@ -149,7 +160,7 @@ export class ButtonTracker {
         if (action === 'Press') {
           this.state = ButtonState.DOWN
           if (this.longPressDisabled) {
-            this.log.info(`button ${this.href} long press disabled. suppressing.`)
+            logButtonPress(this.log, this.buttonPressLogging, `button ${this.href} long press disabled. suppressing.`)
           } else {
             this.timer = setTimeout(longPressTimeoutHandler, this.longPressTimeout)
           }
@@ -187,11 +198,11 @@ export class ButtonTracker {
           this.reset()
 
           if (this.doublePressDisabled) {
-            this.log.info(`button ${this.href} double press disabled. suppressing.`)
+            logButtonPress(this.log, this.buttonPressLogging, `button ${this.href} double press disabled. suppressing.`)
             return
           }
 
-          this.log.info(`button ${this.href} got a double press`)
+          logButtonPress(this.log, this.buttonPressLogging, `button ${this.href} got a double press`)
           this.doublePressCB()
         } else {
           this.log.error(`btrk invalid action ${action} for state ${this.state}. resetting`)

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,0 +1,120 @@
+import type { LogLevel, Logging } from 'homebridge'
+
+/**
+ * Plugin-level log verbosity setting. Stacks on top of Homebridge's own
+ * log handling and the call-site reclassification done in this PR:
+ *
+ *   'normal'      — passthrough. After call-site reclassification, 'info' is
+ *                   reserved for one-time lifecycle events (startup banner,
+ *                   per-device discovery, retry attempts); per-event noise
+ *                   (button presses, mDNS re-announce churn, blind position
+ *                   reads/writes) is at 'debug'. Default.
+ *   'quiet'       — suppress 'info' (and 'success'); pass 'warn'/'error'
+ *                   through. Useful in production where info banners are
+ *                   visual noise but you still want to see anomalies.
+ *   'errors-only' — suppress 'info'/'success' AND 'warn'; pass 'error' only.
+ *
+ * 'debug' is intentionally NEVER suppressed by this wrapper; it is gated by
+ * Homebridge's own debug-mode flag, which is the right axis for that. If a
+ * user has enabled debug deliberately for troubleshooting, suppressing it
+ * here would defeat the purpose.
+ */
+export type LogLevelOption = 'normal' | 'quiet' | 'errors-only'
+
+/**
+ * Per-button-press logging level. Button presses are special-cased because
+ * they're the primary diagnostic an operator wants for "did my press
+ * register?" troubleshooting, but they're also high-volume noise in steady
+ * state.
+ *
+ *   'info'   — visible at info level (legacy behavior; useful when wiring
+ *              up automations and you want to see presses without enabling
+ *              global Homebridge debug).
+ *   'debug'  — visible at debug level only (new default). Quiet in normal
+ *              logs; flip Homebridge's global debug to see presses.
+ *   'silent' — never log presses at any level.
+ */
+export type ButtonPressLogLevel = 'info' | 'debug' | 'silent'
+
+/**
+ * Wraps a Homebridge Logging instance to apply a user-selected verbosity
+ * filter. Returns the original logger unchanged when level is 'normal'
+ * (zero overhead). For 'quiet' and 'errors-only', returns a callable
+ * function wrapper that no-ops the suppressed methods and delegates the
+ * rest to the original logger.
+ *
+ * Wrapping at the platform level cascades to every device class that reads
+ * `this.platform.log` (PicoRemote, OccupancySensor, SerenaTiltOnlyWoodBlinds,
+ * ButtonTracker via PicoRemote), so this single wrap point governs the
+ * whole plugin.
+ */
+export function createFilteredLogger(base: Logging, level: LogLevelOption): Logging {
+  // 'normal' or any unexpected value → passthrough. Defensive: if a hand-edited
+  // config.json supplies a string we don't recognise, never silently suppress.
+  if (level !== 'quiet' && level !== 'errors-only') {
+    return base
+  }
+
+  const suppressInfo = true // both 'quiet' and 'errors-only' suppress info+success
+  const suppressWarn = level === 'errors-only'
+  const noop: (..._args: any[]) => void = () => { /* suppressed by logLevel */ }
+
+  // Logging is callable AND has methods; build a function with attached
+  // properties to satisfy both shapes. The callable form behaves like info().
+  const fn = function wrappedLogger(msg: string, ...params: any[]): void {
+    if (suppressInfo) {
+      return
+    }
+    base(msg, ...params)
+  } as unknown as Logging
+
+  // Methods are bound to the original logger so internal `this` references
+  // (prefix, formatting helpers) still see the right instance.
+  ;(fn as any).prefix = base.prefix
+  ;(fn as any).info = suppressInfo ? noop : base.info.bind(base)
+  ;(fn as any).success = suppressInfo ? noop : base.success.bind(base)
+  ;(fn as any).warn = suppressWarn ? noop : base.warn.bind(base)
+  ;(fn as any).error = base.error.bind(base)
+  ;(fn as any).debug = base.debug.bind(base)
+  ;(fn as any).log = (lvl: LogLevel, msg: string, ...params: any[]) => {
+    // LogLevel is a const enum whose values are the strings 'info'/'success'/
+    // 'warn'/'error'/'debug', so equality checks against string literals are
+    // type-correct and stable across const-enum erasure.
+    if (suppressInfo && (lvl === 'info' || lvl === 'success')) {
+      return
+    }
+    if (suppressWarn && lvl === 'warn') {
+      return
+    }
+    base.log(lvl, msg, ...params)
+  }
+
+  return fn
+}
+
+/**
+ * Emit a button-press log line at the level specified by the user's
+ * 'buttonPressLogging' option. Used by both PicoRemote (for raw
+ * Press/Release events received from the bridge) and ButtonTracker (for
+ * interpreted short/long/double press events derived from the state
+ * machine). Centralised here so the three states stay in sync between
+ * the two call sites.
+ */
+export function logButtonPress(
+  log: Logging,
+  level: ButtonPressLogLevel,
+  message: string,
+  ...params: any[]
+): void {
+  switch (level) {
+    case 'info':
+      log.info(message, ...params)
+      break
+    case 'debug':
+      log.debug(message, ...params)
+      break
+    case 'silent':
+      // intentionally drop
+      break
+  }
+}

--- a/src/LutronCasetaLeapMatterPlatform.ts
+++ b/src/LutronCasetaLeapMatterPlatform.ts
@@ -34,7 +34,9 @@ enum MatterDeviceType {
 export class LutronCasetaLeapMatterPlatform extends LutronCasetaLeap {
   constructor(log: Logging, config: PlatformConfig, api: API) {
     super(log, config, api)
-    log.info('LutronCasetaLeapMatterPlatform: Matter mode active')
+    // Use this.log (wrapped by the base class with the user's logLevel) so
+    // the Matter banner respects the same verbosity setting as everything else.
+    this.log.info('LutronCasetaLeapMatterPlatform: Matter mode active')
   }
 
   /**
@@ -160,9 +162,13 @@ export class LutronCasetaLeapMatterPlatform extends LutronCasetaLeap {
           return '[Unserializable object]'
         }
       }
-      this.log.warn('[Matter Debug] Accessory before registration:', safeStringify(accessory))
-      this.log.warn('[Matter Debug] Accessory.context before registration:', safeStringify(accessory.context))
-      this.log.warn('[Matter Debug] Clusters before registration:', safeStringify(clusters))
+      // These three lines are tagged "[Matter Debug]" and serialise the entire
+      // accessory tree on every Pico scan — they were always intended as
+      // troubleshooting output, never operator-facing warnings. Downgraded from
+      // warn to debug so the prefix and the level finally agree.
+      this.log.debug('[Matter Debug] Accessory before registration:', safeStringify(accessory))
+      this.log.debug('[Matter Debug] Accessory.context before registration:', safeStringify(accessory.context))
+      this.log.debug('[Matter Debug] Clusters before registration:', safeStringify(clusters))
     }
     // Add more device type mappings as needed, using MatterDeviceType enum
 

--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -8,6 +8,7 @@ import { inspect } from 'node:util'
 import { ExceptionDetail } from 'lutron-leap'
 
 import { ButtonTracker } from './ButtonState.js'
+import { logButtonPress } from './Logger.js'
 import { DeviceWireResultType } from './platform.js'
 
 // This maps DeviceType and ButtonNumber to human-readable labels and
@@ -305,6 +306,11 @@ export class PicoRemote {
           this.options.clickSpeedDouble,
           this.options.clickSpeedLong,
           alias.isUpDown,
+          // Thread the user's buttonPressLogging choice into the tracker so
+          // the interpreted short/long/double press lines respect it. The
+          // raw Press/Release event log in handleEvent() below uses the
+          // same option via logButtonPress().
+          this.options.buttonPressLogging,
         ),
       )
 
@@ -365,7 +371,14 @@ export class PicoRemote {
       }
     }
     const fullName = this.accessory.context.device.FullyQualifiedName.join(' ')
-    this.platform.log.info(
+    // Raw Press/Release event from the bridge — fires twice per physical
+    // press (once for Press, once for Release). Routed through
+    // logButtonPress() so the user's buttonPressLogging option (info /
+    // debug / silent) governs visibility, independent of the broader
+    // logLevel option. See Logger.ts.
+    logButtonPress(
+      this.platform.log,
+      this.options.buttonPressLogging,
       `Button ${evt.Button.href} on Pico remote ${fullName} got action ${evt.ButtonEvent.EventType}`,
     )
     this.trackers.get(evt.Button.href)!.update(evt.ButtonEvent.EventType)

--- a/src/SerenaTiltOnlyWoodBlinds.ts
+++ b/src/SerenaTiltOnlyWoodBlinds.ts
@@ -90,7 +90,10 @@ export class SerenaTiltOnlyWoodBlinds {
     )
     const tilt = await this.bridge.readBlindsTilt(this.device)
     const adj_val = Math.min(100, tilt * 2)
-    this.platform.log.info(
+    // Per-poll noise — Homebridge re-reads position frequently. Was info
+    // (visible in normal logs); now debug so steady-state operation stays
+    // quiet, with global debug bringing it back when troubleshooting.
+    this.platform.log.debug(
       'Told Homekit that blinds',
       this.device.FullyQualifiedName.join(' '),
       'are at position',
@@ -101,7 +104,9 @@ export class SerenaTiltOnlyWoodBlinds {
 
   async handleTargetPositionSet(value: CharacteristicValue): Promise<void> {
     const adj_val = Number(value) / 2
-    this.platform.log.info(
+    // Per-command noise — fires every time HomeKit drives the blind. Was
+    // info; now debug.
+    this.platform.log.debug(
       'Commanded',
       this.device.FullyQualifiedName.join(' '),
       'blinds to (adjusted) value',
@@ -118,7 +123,9 @@ export class SerenaTiltOnlyWoodBlinds {
     if (response.Header.MessageBodyType === 'OneZoneStatus') {
       if ((response.Body as OneZoneStatus)?.ZoneStatus?.Zone?.href === this.device.LocalZones[0].href) {
         const adj_val = Math.min(100, (response.Body as OneZoneStatus).ZoneStatus.Tilt * 2)
-        this.platform.log.info(
+        // Per state-change noise — fires on every physical blind movement.
+        // Was info; now debug.
+        this.platform.log.debug(
           'Blinds',
           this.device.FullyQualifiedName.join(' '),
           'reported a new position of',

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,6 +20,9 @@ import {
   SmartBridge,
 } from 'lutron-leap'
 
+import type { ButtonPressLogLevel, LogLevelOption } from './Logger.js'
+
+import { createFilteredLogger } from './Logger.js'
 import { OccupancySensor } from './OccupancySensor.js'
 import { PicoRemote } from './PicoRemote.js'
 import { SerenaTiltOnlyWoodBlinds } from './SerenaTiltOnlyWoodBlinds.js'
@@ -37,6 +40,13 @@ export interface GlobalOptions {
   clickSpeedLong: 'quick' | 'default' | 'relaxed' | 'disabled'
   clickSpeedDouble: 'quick' | 'default' | 'relaxed' | 'disabled'
   logSSLKeyDangerous: boolean
+  // Plugin-level log verbosity. See src/Logger.ts for what each value does.
+  logLevel: LogLevelOption
+  // Specifically governs button-press log lines (raw Press/Release events
+  // and interpreted short/long/double press events). Independent of logLevel
+  // so users can silence presses without quieting the rest, or surface them
+  // for automation setup without enabling global Homebridge debug.
+  buttonPressLogging: ButtonPressLogLevel
 }
 
 interface BridgeAuthEntry {
@@ -77,18 +87,35 @@ export class LutronCasetaLeap
   private options: GlobalOptions
   private secrets: Map<string, BridgeAuthEntry>
   private bridgeMgr: Map<string, SmartBridge> = new Map()
+  // Log is declared as a regular field rather than a constructor parameter
+  // property because we need to wrap it (with the user's logLevel filter)
+  // before the rest of the constructor — and parameter properties are
+  // assigned implicitly at the start of the constructor, before user code
+  // runs. Wrapping at the platform level cascades to every device class
+  // that reads `this.platform.log`.
+  public readonly log: Logging
 
-  constructor(public readonly log: Logging, public readonly config: PlatformConfig, public readonly api: API) {
+  constructor(log: Logging, public readonly config: PlatformConfig, public readonly api: API) {
     super()
 
-    log.info('LutronCasetaLeap starting up...')
+    // Read options first so we know which verbosity level to wrap at, then
+    // wrap, then use this.log for everything else. createFilteredLogger
+    // returns the original instance unchanged when level is 'normal' (the
+    // default), so the only-overhead path is the active-filter case.
+    this.options = this.optionsFromConfig(config)
+    this.log = createFilteredLogger(log, this.options.logLevel)
+
+    this.log.info('LutronCasetaLeap starting up...')
 
     process.on('warning', e => this.log.warn(`Got ${e.name} process warning: ${e.message}:\n${e.stack}`))
 
-    this.options = this.optionsFromConfig(config)
     this.secrets = this.secretsFromConfig(config)
     if (this.secrets.size === 0) {
-      log.warn('No bridge auth configured. Retiring.')
+      // Bumped from warn to error: with no secrets the plugin can do
+      // nothing, so this must bypass any user-configured 'errors-only'
+      // filter and demand attention. (Previously a warn, which would have
+      // been suppressed under the new errors-only logLevel.)
+      this.log.error('No bridge auth configured. Retiring.')
       return
     }
 
@@ -104,12 +131,12 @@ export class LutronCasetaLeap
          * This event can also be used to start discovery of new accessories.
          */
     api.on(APIEvent.DID_FINISH_LAUNCHING, () => {
-      log.info('Finished launching; starting up automatic discovery')
+      this.log.info('Finished launching; starting up automatic discovery')
 
       this.finder = new BridgeFinder()
       this.finder.on('discovered', this.handleBridgeDiscovery.bind(this))
       this.finder.on('failed', (error) => {
-        log.error('Could not connect to discovered hub:', error)
+        this.log.error('Could not connect to discovered hub:', error)
       })
       this.finder.beginSearching()
     })
@@ -130,7 +157,7 @@ export class LutronCasetaLeap
       this.log.info(`Heap dump to ${fileName} finished.`)
     })
 
-    log.info('LutronCasetaLeap plugin finished early initialization')
+    this.log.info('LutronCasetaLeap plugin finished early initialization')
   }
 
   optionsFromConfig(config: PlatformConfig): GlobalOptions {
@@ -141,6 +168,14 @@ export class LutronCasetaLeap
         clickSpeedDouble: 'default',
         clickSpeedLong: 'default',
         logSSLKeyDangerous: false,
+        // Defaults reflect the post-reclassification "sane quiet by default"
+        // posture. logLevel 'normal' means the wrapper is a passthrough; the
+        // quietness comes from the call sites being correctly classified.
+        // buttonPressLogging 'debug' means presses are not visible in normal
+        // logs (a behavior change from earlier versions); use 'info' to
+        // restore the old chatty behavior, or 'silent' to drop them entirely.
+        logLevel: 'normal',
+        buttonPressLogging: 'debug',
       },
       config.options,
     )
@@ -172,10 +207,15 @@ export class LutronCasetaLeap
     if (this.bridgeMgr.has(bridgeID)) {
       // this is an existing bridge re-announcing itself, so we'll recycle the connection to it
       if (this.bridgeMgr.get(bridgeID)!.bridgeReconfigInProgress === true) {
-        this.log.info('Bridge', bridgeInfo.bridgeid, 'reconfiguration in progress, do nothing.')
+        // Per mDNS re-announcement noise — fires constantly during steady
+        // state. Was info; now debug. (See PR conversation: this trio of
+        // bridge-state lines was the user's primary complaint about info-
+        // level noise.)
+        this.log.debug('Bridge', bridgeInfo.bridgeid, 'reconfiguration in progress, do nothing.')
         return
       }
-      this.log.info('Bridge', bridgeInfo.bridgeid, 'already known, will skip setup.')
+      // Same — fires on every mDNS re-announce after the first. info → debug.
+      this.log.debug('Bridge', bridgeInfo.bridgeid, 'already known, will skip setup.')
       replaceClient = true
     }
 
@@ -216,9 +256,11 @@ export class LutronCasetaLeap
         //  - devices ask bridge to re-subscribe
         //  - bridge uses new client to re-subscribe
         //  - old client goes out of scope
-        this.log.info('Bridge', bridgeInfo.bridgeid, 'entering reconfiguration')
+        // Bookend an internal reconfigure operation. Useful when debugging
+        // a reconfigure issue, but normal-path noise otherwise. info → debug.
+        this.log.debug('Bridge', bridgeInfo.bridgeid, 'entering reconfiguration')
         await this.bridgeMgr.get(bridgeID)!.reconfigureBridge(client)
-        this.log.info('Bridge', bridgeInfo.bridgeid, 'exit reconfiguration')
+        this.log.debug('Bridge', bridgeInfo.bridgeid, 'exit reconfiguration')
       } else {
         const bridge = new SmartBridge(bridgeID, client)
 
@@ -231,7 +273,10 @@ export class LutronCasetaLeap
         this.processAllDevices(bridge)
       }
     } else {
-      this.log.info('no credentials from bridge ID', bridgeInfo.bridgeid)
+      // Multi-bridge scenario noise — if the user has 2 bridges and only
+      // configured 1, the unconfigured one will hit this branch on every
+      // mDNS announce. info → debug.
+      this.log.debug('no credentials from bridge ID', bridgeInfo.bridgeid)
     }
   }
 
@@ -269,7 +314,12 @@ export class LutronCasetaLeap
       for (const result of results) {
         switch (result.status) {
           case 'fulfilled': {
-            this.log.info(`Device setup finished: ${result.value}`)
+            // Fires per device per scan (e.g., 11 lines on every refresh
+            // for a setup with 11 Picos). The "Found a {DeviceType} ..."
+            // info lines emitted earlier already announce discovery; this
+            // line is just confirmation that wiring didn't throw, which
+            // is the normal outcome. info → debug.
+            this.log.debug(`Device setup finished: ${result.value}`)
             break
           }
           case 'rejected': {


### PR DESCRIPTION
## Summary

Reclassifies a handful of call sites that were emitting at info level when they're per-event noise, and adds two new config options so users can dial verbosity up or down without touching Homebridge's global debug flag.

### Reclassifications (info → debug for per-event noise)

| File:line | Line | Why |
|---|---|---|
| platform.ts | `Bridge X reconfiguration in progress, do nothing.` | Per mDNS re-announce — fires constantly |
| platform.ts | `Bridge X already known, will skip setup.` | Same |
| platform.ts | `Bridge X entering reconfiguration` / `exit reconfiguration` | Bookend an internal op; normal-path noise |
| platform.ts | `Device setup finished: X` | Per-device per-scan; 11 Picos = 11 lines per refresh |
| platform.ts | `no credentials from bridge ID X` | Multi-bridge scenario noise |
| Serena…ts | `Told Homekit blinds X are at position N` | Per HomeKit poll |
| Serena…ts | `Commanded X blinds to value N` | Per command |
| Serena…ts | `Blinds X reported a new position of N` | Per state change |
| Matter…ts | `[Matter Debug] ...` (×3) | Already tagged 'Debug'; were warn by mistake |

### One bump up

| File:line | Line | Old | New | Why |
|---|---|---|---|---|
| platform.ts | `No bridge auth configured. Retiring.` | warn | error | Plugin can't function without auth — must bypass any user-configured 'errors-only' filter. |

### New: `logLevel` config option

Three-state dropdown, default `normal`:

- **`normal`** — passthrough. After call-site reclassification, info is reserved for one-time lifecycle events (startup, per-device discovery, retry attempts).
- **`quiet`** — suppresses info+success; passes warn/error/debug.
- **`errors-only`** — suppresses info+success+warn; passes error/debug.

Implemented as a logger wrapper applied once in the platform constructor; cascades automatically to every device class via `this.platform.log`. `normal` is a no-op passthrough (zero overhead); the wrapper allocation only happens for active filters.

`debug` is intentionally never suppressed by this wrapper — it's gated by Homebridge's own debug flag, which is the right axis for that. If a user has explicitly enabled debug for troubleshooting, suppressing it here would defeat the purpose.

### New: `buttonPressLogging` config option

Three-state dropdown, default `debug`:

- **`debug`** — presses quiet in normal logs; visible only with global Homebridge debug enabled.
- **`info`** — presses visible in normal logs (legacy 3.0.x behavior; useful for automation setup without enabling global debug).
- **`silent`** — presses never logged, even with global debug.

Governs the raw Press/Release event log in `PicoRemote.handleEvent` and the interpreted short/long/double press lines in `ButtonTracker`. Independent of `logLevel` so users can silence presses without quieting the rest, or surface them at info-level without enabling global debug.

### Behavior change for existing users

Button-press lines that were at info level in 3.0.x are now at debug by default. Set `buttonPressLogging: \"info\"` in config to restore the old chatty behavior. Documented in the README.

## Implementation

- **New file** `src/Logger.ts` — `createFilteredLogger()`, `logButtonPress()`, and the `LogLevelOption` / `ButtonPressLogLevel` types.
- `platform.ts` — `log` changed from constructor parameter property to a regular field so we can wrap it with the user's chosen verbosity AFTER reading options. Constructor reorder: parse options, wrap log, then everything else.
- `ButtonState.ts` — `ButtonTracker` takes a new `buttonPressLogging` parameter (defaults to `'debug'` if omitted); all five press-related log calls go through `logButtonPress()`.
- `PicoRemote.ts` — passes `options.buttonPressLogging` to `ButtonTracker`; the raw Press/Release log uses `logButtonPress()` too.
- `LutronCasetaLeapMatterPlatform.ts` — \"Matter mode active\" banner moved from `log.info` to `this.log.info` so it respects `logLevel` like everything else.
- `config.schema.json` — two new properties with descriptions and dropdown enums; layout entries so they render in the standard Homebridge UI.
- `README.md` — new \"Log Verbosity\" section under Options; example config updated.

Each non-trivial change carries an inline comment explaining why, so a maintainer reading the diff cold has the rationale embedded.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Schema validity check (`json.load`) — passes
- [x] Audited every remaining `log.info`/`log.warn`/`log.error` call site against the litmus test \"if it fires more than ~once per device per session, it's debug\" — 11 info, 7 warn, 7 error sites all check out
- [x] Verified compiled `dist/` contains all new strings