### PR TITLE
fix(filterPico): catch empty AffectedZones and scene-bound presets

### DIFF
--- a/src/PicoRemote.test.ts
+++ b/src/PicoRemote.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { presetIsProgrammed } from './PicoRemote.js'
+
+describe('presetIsProgrammed', () => {
+  it('treats the empty Preset shell as not programmed', () => {
+    expect(presetIsProgrammed({ href: '/preset/229', Parent: { href: '/programmingmodel/216' } })).toBe(false)
+  })
+
+  it('treats null/undefined/non-object as not programmed', () => {
+    expect(presetIsProgrammed(null)).toBe(false)
+    expect(presetIsProgrammed(undefined)).toBe(false)
+    expect(presetIsProgrammed('preset')).toBe(false)
+    expect(presetIsProgrammed(42)).toBe(false)
+  })
+
+  it('treats empty assignment arrays as not programmed', () => {
+    expect(presetIsProgrammed({ href: '/p/1', Parent: { href: '/pm/1' }, PresetAssignments: [] })).toBe(false)
+  })
+
+  it('detects scene-style PresetAssignments (the common dimmer/switch case)', () => {
+    expect(presetIsProgrammed({
+      href: '/preset/173',
+      Parent: { href: '/programmingmodel/164' },
+      PresetAssignments: [{ href: '/presetassignment/50' }],
+      DimmedLevelAssignments: [{ href: '/dimmedlevelassignment/50' }],
+    })).toBe(true)
+  })
+
+  it('detects audio-Pico Preset families (PlayPauseToggle, NextTrack, FavoriteCycle)', () => {
+    expect(presetIsProgrammed({
+      href: '/preset/222',
+      Parent: { href: '/programmingmodel/210' },
+      PlayPauseToggleAssignments: [{ href: '/playpausetoggleassignment/1' }],
+    })).toBe(true)
+    expect(presetIsProgrammed({
+      href: '/preset/224',
+      Parent: { href: '/programmingmodel/212' },
+      NextTrackAssignments: [{ href: '/nexttrackassignment/3' }],
+    })).toBe(true)
+    expect(presetIsProgrammed({
+      href: '/preset/223',
+      Parent: { href: '/programmingmodel/211' },
+      FavoriteCycleAssignments: [{ href: '/favoritecycleassignment/2' }],
+    })).toBe(true)
+  })
+
+  it('detects unknown future *Assignments families generically', () => {
+    expect(presetIsProgrammed({
+      href: '/preset/1',
+      Parent: { href: '/pm/1' },
+      ImaginaryFutureAssignments: [{ href: '/imaginary/1' }],
+    })).toBe(true)
+  })
+})

--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -154,15 +154,6 @@ export class PicoRemote {
       }
     }
 
-    // if there are any buttongroups that are already associated in the
-    // lutron app, and we've been told to skip them, return early.
-    if (bgs.some(bg => bg.AffectedZones !== undefined) && this.options.filterPico) {
-      return {
-        kind: DeviceWireResultType.Skipped,
-        reason: 'Associated with a device outside HomeKit',
-      }
-    }
-
     // Bail out if the bridge returned an ExceptionDetail for any button group
     // (typically when the device is mid-removal in the Lutron app). The previous
     // code used forEach with `return new Error(...)` — both the return and the
@@ -188,6 +179,66 @@ export class PicoRemote {
         return {
           kind: DeviceWireResultType.Error,
           reason: `Failed to get buttons from button group ${bg.href}: ${e}`,
+        }
+      }
+    }
+
+    // If we've been told to skip Picos already associated in the Lutron app,
+    // do a two-stage check.
+    //
+    // Stage 1 (cheap): any button group with non-empty AffectedZones is
+    // wired to a light/dimmer/switch/scene in the Lutron app.
+    //
+    // The previous check `AffectedZones !== undefined` was always true on
+    // the wire even for empty arrays, so it skipped audio Picos, fan Picos,
+    // and scene-only Picos that carry an empty AffectedZones field but
+    // still have real programming. The opposite of the desired behaviour.
+    //
+    // Stage 2 (deep): for Picos with no zone wiring, every button reports
+    // ProgrammingModelType: 'SingleActionProgrammingModel' regardless of
+    // whether the user has actually programmed it - so the only ground
+    // truth is whether each button's linked Preset carries assignments.
+    // Unprogrammed Presets are a bare {href, Parent} shell. Programmed
+    // ones carry one or more *Assignments arrays (PresetAssignments,
+    // DimmedLevelAssignments, SwitchedLevelAssignments, FanSpeedAssignments,
+    // PlayPauseToggleAssignments, NextTrackAssignments, FavoriteCycleAssignments,
+    // RaiseLowerAssignments, etc).
+    if (this.options.filterPico) {
+      const wired = bgs.find(bg => Array.isArray(bg.AffectedZones) && bg.AffectedZones.length > 0)
+      if (wired) {
+        return {
+          kind: DeviceWireResultType.Skipped,
+          reason: `Associated with a device outside HomeKit (${wired.href} has ${wired.AffectedZones!.length} zone(s) wired)`,
+        }
+      }
+      for (const button of buttons) {
+        const pmHref = (button.ProgrammingModel as { href?: string } | undefined)?.href
+        if (!pmHref)
+          continue
+        let pm: { Preset?: { href?: string } } | undefined
+        try {
+          const resp = await this.bridge.getHref({ href: pmHref } as any) as any
+          pm = resp?.ProgrammingModel ?? resp
+        } catch (e) {
+          this.platform.log.warn(`Failed to read programming model ${pmHref} for ${fullName}: ${e}; treating ${button.href} as unprogrammed`)
+          continue
+        }
+        const presetHref = pm?.Preset?.href
+        if (!presetHref)
+          continue
+        let preset: unknown
+        try {
+          const resp = await this.bridge.getHref({ href: presetHref } as any) as any
+          preset = resp?.Preset ?? resp
+        } catch (e) {
+          this.platform.log.warn(`Failed to read preset ${presetHref} for ${fullName}: ${e}; treating ${button.href} as unprogrammed`)
+          continue
+        }
+        if (presetIsProgrammed(preset)) {
+          return {
+            kind: DeviceWireResultType.Skipped,
+            reason: `Associated with a device outside HomeKit (${button.href} preset ${presetHref} has assignments)`,
+          }
         }
       }
     }
@@ -440,4 +491,23 @@ export class PicoRemote {
     }
     return clusters
   }
+}
+
+// A LEAP Preset is "programmed" if it carries any non-empty assignment array.
+// The unprogrammed shape is just {href, Parent}. Programmed Presets carry one
+// or more of: PresetAssignments, DimmedLevelAssignments, SwitchedLevelAssignments,
+// FanSpeedAssignments, TiltAssignments, PlayPauseToggleAssignments,
+// NextTrackAssignments, FavoriteCycleAssignments, RaiseLowerAssignments, etc.
+// We don't enumerate the families - any *Assignments-shaped key with content
+// counts, which makes the check forward-compatible with future LEAP types.
+export function presetIsProgrammed(preset: unknown): boolean {
+  if (!preset || typeof preset !== 'object')
+    return false
+  for (const [k, v] of Object.entries(preset as Record<string, unknown>)) {
+    if (k === 'href' || k === 'Parent')
+      continue
+    if (Array.isArray(v) && v.length > 0)
+      return true
+  }
+  return false
 }

--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -220,7 +220,7 @@ export class PicoRemote {
           const resp = await this.bridge.getHref({ href: pmHref } as any) as any
           pm = resp?.ProgrammingModel ?? resp
         } catch (e) {
-          this.platform.log.warn(`Failed to read programming model ${pmHref} for ${fullName}: ${e}; treating ${button.href} as unprogrammed`)
+          this.platform.log.warn(`Failed to read programming model ${pmHref} for ${fullName}; treating ${button.href} as unprogrammed:`, e)
           continue
         }
         const presetHref = pm?.Preset?.href
@@ -231,7 +231,7 @@ export class PicoRemote {
           const resp = await this.bridge.getHref({ href: presetHref } as any) as any
           preset = resp?.Preset ?? resp
         } catch (e) {
-          this.platform.log.warn(`Failed to read preset ${presetHref} for ${fullName}: ${e}; treating ${button.href} as unprogrammed`)
+          this.platform.log.warn(`Failed to read preset ${presetHref} for ${fullName}; treating ${button.href} as unprogrammed:`, e)
           continue
         }
         if (presetIsProgrammed(preset)) {
@@ -498,13 +498,14 @@ export class PicoRemote {
 // or more of: PresetAssignments, DimmedLevelAssignments, SwitchedLevelAssignments,
 // FanSpeedAssignments, TiltAssignments, PlayPauseToggleAssignments,
 // NextTrackAssignments, FavoriteCycleAssignments, RaiseLowerAssignments, etc.
-// We don't enumerate the families - any *Assignments-shaped key with content
-// counts, which makes the check forward-compatible with future LEAP types.
+// We don't enumerate the families - any key whose name ends in "Assignments"
+// with a non-empty array counts, which makes the check forward-compatible
+// with future LEAP types while ignoring unrelated array fields LEAP may add.
 export function presetIsProgrammed(preset: unknown): boolean {
   if (!preset || typeof preset !== 'object')
     return false
   for (const [k, v] of Object.entries(preset as Record<string, unknown>)) {
-    if (k === 'href' || k === 'Parent')
+    if (!k.endsWith('Assignments'))
       continue
     if (Array.isArray(v) && v.length > 0)
       return true


### PR DESCRIPTION
## Summary

The current `filterPico` check at `src/PicoRemote.ts:159` is `bgs.some(bg => bg.AffectedZones !== undefined)`. This has two problems on real Caséta Smart Bridge Pro data:

1. `AffectedZones !== undefined` is true even when the array is *empty*. Audio Picos, fan Picos, and scene-only Picos all carry `AffectedZones: []` plus real programming via Presets. So they look "associated" by accident, and the filter happens to skip them for the wrong reason.

2. The bigger issue: Picos bound only to scenes/audio/fan-control through the Lutron app would otherwise be added to HomeKit even though they are clearly already in use. Their programming lives one level deeper, on the `Preset` attached to each button's `ProgrammingModel`.

I confirmed on a real 17-Pico install that **every** button on **every** Pico reports `ProgrammingModelType: "SingleActionProgrammingModel"` regardless of whether the user has actually programmed it, so neither the existing `AffectedZones` shortcut nor `ProgrammingModelType` can discriminate. The only ground truth is whether the linked Preset itself carries any non-empty `*Assignments` array.

## What changes

Two-stage filter, gated by the existing `filterPico` config (no new config knobs, default behaviour unchanged for users who don't enable filtering):

- **Stage 1 (cheap):** any button group with `AffectedZones?.length > 0` → skip. Short-circuits without any extra network calls, so zone-wired Picos (the common case) pay nothing.
- **Stage 2 (deep):** for Picos with no zone wiring, fetch each button's `ProgrammingModel` then its `Preset`, and skip if any preset has a non-empty `*Assignments` array. Generic over the family (`PresetAssignments`, `DimmedLevelAssignments`, `SwitchedLevelAssignments`, `FanSpeedAssignments`, `TiltAssignments`, `PlayPauseToggleAssignments`, `NextTrackAssignments`, `FavoriteCycleAssignments`, `RaiseLowerAssignments`, plus any future shape) so we don't have to enumerate.

Skipped reason strings now include the diagnostic href (button group / button / preset) so users can see *why* a Pico got skipped.

## Reproducer / evidence

On the 17-Pico install:

| Pico | Lutron app state | Existing filter | This patch |
|---|---|---|---|
| 9 zone-wired Picos (e.g. "Bedroom Overhead Remote 1", "Side Porch 4 Button Pico") | wired to lights/dimmers | skipped ✓ | skipped via stage 1 ✓ |
| Kitchen Keypad, Family Room Home/Away, Family Room Named Scene, Bedroom Keypad 1, Bedroom Keypad 2 | scene-bound (PresetAssignments + DimmedLevelAssignments) | **incorrectly added** ✗ | skipped via stage 2 ✓ |
| Family Room Audio Pico | audio playback (PlayPauseToggleAssignments / FavoriteCycleAssignments / NextTrackAssignments) | **incorrectly added** ✗ | skipped via stage 2 ✓ |
| Main Bedroom Pico Fan | unprogrammed (bare `{href, Parent}` Preset) | added ✓ | added ✓ |

Net: previously 7 Picos exposed (1 correct, 6 incorrect). With this patch, 1 Pico exposed (the only genuinely unassociated one).

## Test plan

- [x] `npx tsc` clean
- [x] `npm test` 36/36 passing (was 30/30; 6 new tests added in `src/PicoRemote.test.ts` for `presetIsProgrammed` covering empty-shell, null/undefined, empty-array, scene-style, audio-Pico families, generic forward-compat)
- [x] Verified end-to-end on a live 17-Pico Smart Bridge Pro install (table above)

## Notes for reviewers

- The deep-check fetches happen sequentially per button. On the 17-Pico install only Picos with no zone wiring trigger any deep fetches, and each Pico has 4–5 buttons → at most 5 PM + 5 Preset reads. In practice startup time was unchanged.
- Errors fetching ProgrammingModel or Preset are downgraded to `warn` and the button is treated as unprogrammed rather than failing the whole Pico — matches the spirit of the existing filter (skipping is a soft optimisation).
- No public API change. `presetIsProgrammed` is exported only so the unit test can target it.