### PR TITLE
fix: repair stale LEAP connections with a per-bridge ping watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - chore: remove personal funding links
 - docs: add node 26 to the supported node versions
 - chore: exclude test files and the test config from the published package
+- fix: repair stale LEAP connections with a per-bridge ping watchdog
 
 ## v3.1.7 (2026-07-27)
 

--- a/src/ConnectionWatchdog.test.ts
+++ b/src/ConnectionWatchdog.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConnectionWatchdog } from './ConnectionWatchdog.js'
+
+function makeLog(): any {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeWatchdog(overrides: Partial<ConstructorParameters<typeof ConnectionWatchdog>[0]> = {}) {
+  const ping = vi.fn().mockResolvedValue({})
+  const revive = vi.fn().mockResolvedValue(undefined)
+  const log = makeLog()
+  const watchdog = new ConnectionWatchdog({
+    bridgeLabel: 'test-bridge',
+    ping,
+    revive,
+    log,
+    pingIntervalMs: 1000,
+    pingTimeoutMs: 100,
+    failureThreshold: 3,
+    ...overrides,
+  })
+  return { watchdog, ping, revive, log }
+}
+
+describe('connectionWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('pings on the configured interval and never revives while pings succeed', async () => {
+    const { watchdog, ping, revive } = makeWatchdog()
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(ping).toHaveBeenCalledTimes(5)
+    expect(revive).not.toHaveBeenCalled()
+    watchdog.stop()
+  })
+
+  it('revives after the failure threshold and resets the counter afterwards', async () => {
+    const ping = vi.fn().mockRejectedValue(new Error('connection dead'))
+    const { watchdog, revive } = makeWatchdog({ ping })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(revive).toHaveBeenCalledTimes(1)
+
+    // Counter was reset: two more failures are not enough for a second revive...
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(revive).toHaveBeenCalledTimes(1)
+
+    // ...but the third one is.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(revive).toHaveBeenCalledTimes(2)
+    watchdog.stop()
+  })
+
+  it('treats a ping that never settles as a failure via its own timeout', async () => {
+    // Reproduces the lutron-leap hazard: request() arms its timeout inside
+    // the socket.write callback, so a write against a dead socket can hang
+    // the promise forever. The watchdog must not hang with it.
+    const ping = vi.fn(() => new Promise(() => { /* never settles */ }))
+    const { watchdog, revive } = makeWatchdog({ ping, failureThreshold: 1 })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(1100) // interval fires at 1000, timeout at +100
+    expect(revive).toHaveBeenCalledTimes(1)
+    watchdog.stop()
+  })
+
+  it('a successful ping resets the consecutive-failure count', async () => {
+    let failing = true
+    const ping = vi.fn(() => (failing ? Promise.reject(new Error('down')) : Promise.resolve({})))
+    const { watchdog, revive } = makeWatchdog({ ping })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(2000) // two failures
+    failing = false
+    await vi.advanceTimersByTimeAsync(1000) // success; counter resets
+    failing = true
+    await vi.advanceTimersByTimeAsync(2000) // two failures again, still below threshold
+    expect(revive).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000) // third consecutive failure
+    expect(revive).toHaveBeenCalledTimes(1)
+    watchdog.stop()
+  })
+
+  it('skips pings while skip() reports the bridge is mid-reconfiguration', async () => {
+    const { watchdog, ping, revive } = makeWatchdog({ skip: () => true })
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(ping).not.toHaveBeenCalled()
+    expect(revive).not.toHaveBeenCalled()
+    watchdog.stop()
+  })
+
+  it('keeps running when revive itself fails', async () => {
+    const ping = vi.fn().mockRejectedValue(new Error('down'))
+    const revive = vi.fn().mockRejectedValue(new Error('bridge still unreachable'))
+    const { watchdog, log } = makeWatchdog({ ping, revive })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(revive).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalled()
+
+    // Another three failures trigger another attempt rather than giving up.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(revive).toHaveBeenCalledTimes(2)
+    watchdog.stop()
+  })
+
+  it('never runs two revives concurrently', async () => {
+    // Guards the `reviving` flag. Without it, a revive that takes longer than
+    // the ping interval would be re-entered on every tick, stacking teardowns
+    // of the same bridge on top of each other.
+    const ping = vi.fn().mockRejectedValue(new Error('down'))
+    let inFlight = 0
+    let maxConcurrent = 0
+    const revive = vi.fn(() => {
+      inFlight++
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          inFlight--
+          resolve()
+        }, 10_000)
+      })
+    })
+    const { watchdog } = makeWatchdog({ ping, revive })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(12_000)
+    expect(revive).toHaveBeenCalledTimes(1)
+    expect(maxConcurrent).toBe(1)
+    watchdog.stop()
+  })
+
+  it('uses the documented production cadence when no overrides are given', async () => {
+    // Pins the "detected and repaired within about three minutes" contract:
+    // 60s interval, 3 strikes.
+    const ping = vi.fn().mockRejectedValue(new Error('down'))
+    const revive = vi.fn().mockResolvedValue(undefined)
+    const watchdog = new ConnectionWatchdog({ bridgeLabel: 'b', ping, revive, log: makeLog() })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(ping).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2)
+    expect(ping).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(ping).toHaveBeenCalledTimes(3)
+    expect(revive).toHaveBeenCalledTimes(1)
+    watchdog.stop()
+  })
+
+  it('unrefs its interval so it cannot hold the process open', () => {
+    const unref = vi.fn()
+    const spy = vi.spyOn(globalThis, 'setInterval').mockReturnValue({ unref } as any)
+    try {
+      const { watchdog } = makeWatchdog()
+      watchdog.start()
+      expect(unref).toHaveBeenCalled()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not count a ping lost to an in-flight reconfigure as a strike', async () => {
+    // reconfigureBridge() calls drain(), which discards in-flight requests
+    // without settling them. The ping we lose says nothing about the health of
+    // the replacement connection, so it must not push us toward a teardown.
+    let reconfiguring = false
+    const ping = vi.fn(() => new Promise((_r, reject) => {
+      setTimeout(() => {
+        reconfiguring = true
+        reject(new Error('drained'))
+      }, 50)
+    }))
+    const { watchdog, revive } = makeWatchdog({ ping, skip: () => reconfiguring, failureThreshold: 1 })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(ping).toHaveBeenCalled()
+    expect(revive).not.toHaveBeenCalled()
+    watchdog.stop()
+  })
+
+  it('calls onHealthy after a successful ping so an interrupted repair can finish', async () => {
+    const onHealthy = vi.fn()
+    const { watchdog } = makeWatchdog({ onHealthy })
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(onHealthy).toHaveBeenCalledTimes(2)
+    watchdog.stop()
+  })
+
+  it('runs onHealthy on the first success after a failed revive', async () => {
+    // The dangerous sequence: a revive dies partway, destroying every LEAP
+    // subscription, and then the bridge starts answering pings again. The ping
+    // looks healthy but no events are being delivered, so the platform has to
+    // be told to re-subscribe.
+    let failing = true
+    const ping = vi.fn(() => (failing ? Promise.reject(new Error('down')) : Promise.resolve({})))
+    const revive = vi.fn().mockRejectedValue(new Error('bridge still rebooting'))
+    const onHealthy = vi.fn()
+    const { watchdog } = makeWatchdog({ ping, revive, onHealthy })
+    watchdog.start()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(revive).toHaveBeenCalledTimes(1)
+    expect(onHealthy).not.toHaveBeenCalled()
+
+    failing = false
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(onHealthy).toHaveBeenCalledTimes(1)
+    watchdog.stop()
+  })
+
+  it('a failure inside onHealthy does not break the ping loop', async () => {
+    const onHealthy = vi.fn().mockRejectedValue(new Error('resubscribe blew up'))
+    const { watchdog, ping } = makeWatchdog({ onHealthy })
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(ping).toHaveBeenCalledTimes(3)
+    watchdog.stop()
+  })
+
+  it('stop() prevents a revive from starting after shutdown', async () => {
+    const ping = vi.fn().mockRejectedValue(new Error('down'))
+    const { watchdog, revive } = makeWatchdog({ ping })
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(2000)
+    watchdog.stop()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(revive).not.toHaveBeenCalled()
+  })
+
+  it('start() is idempotent and stop() halts pinging', async () => {
+    const { watchdog, ping } = makeWatchdog()
+    watchdog.start()
+    watchdog.start()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(ping).toHaveBeenCalledTimes(2) // not doubled by the second start()
+
+    watchdog.stop()
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(ping).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/ConnectionWatchdog.ts
+++ b/src/ConnectionWatchdog.ts
@@ -1,0 +1,161 @@
+import type { Logging } from 'homebridge'
+
+import { withTimeout } from './utils.js'
+
+// Why this exists: lutron-leap detects dead connections (its own ping loop
+// fires every 5 minutes) but deliberately never repairs them; the .catch in
+// SmartBridge.startPingLoop is a documented no-op. Repair only happens when
+// the socket emits 'close' (never happens for half-open connections after a
+// router reboot or Wi-Fi blip) or when an mDNS re-announce arrives (best
+// effort at most). Without this watchdog, a silently dead connection stays
+// dead until Homebridge restarts.
+//
+// Defaults are chosen so a dead connection is detected and repaired within
+// about three minutes: three failed pings, 60 seconds apart.
+const DEFAULT_PING_INTERVAL_MS = 60_000
+const DEFAULT_PING_TIMEOUT_MS = 10_000
+const DEFAULT_FAILURE_THRESHOLD = 3
+
+export interface ConnectionWatchdogOptions {
+  /** Identifies the bridge in log lines. */
+  bridgeLabel: string
+  /** Sends a lightweight request over the current connection. */
+  ping: () => Promise<unknown>
+  /**
+   * Tears down and replaces the connection. Called after `failureThreshold`
+   * consecutive ping failures. May resolve `false` to signal it stood down
+   * because another repair path was already handling the bridge.
+   */
+  revive: () => Promise<boolean | void>
+  /**
+   * Returns true while the bridge is mid-reconfiguration (the mDNS
+   * re-announce path replacing the client). Pings are skipped during that
+   * window so a deliberate teardown is not misread as staleness.
+   */
+  skip?: () => boolean
+  /**
+   * Called after every successful ping. A ping is NOT proof the plugin is
+   * working: lutron-leap's request() awaits connect(), so a ping transparently
+   * opens a fresh socket, and a fresh socket has no LEAP subscriptions on it.
+   * A reachable bridge with no subscriptions delivers no button presses at
+   * all, so the platform uses this hook to finish any repair an interrupted
+   * revive left outstanding.
+   */
+  onHealthy?: () => Promise<void> | void
+  log: Logging
+  pingIntervalMs?: number
+  pingTimeoutMs?: number
+  failureThreshold?: number
+}
+
+export class ConnectionWatchdog {
+  private timer: ReturnType<typeof setInterval> | null = null
+  private consecutiveFailures = 0
+  private reviving = false
+  private stopped = false
+  // Consecutive failed revive attempts, used only to keep the log quiet when a
+  // bridge is off for a long time (unplugged, away for the weekend). The repair
+  // cadence itself is unchanged; it is the warn/error spam every ~3 minutes
+  // that would otherwise be a problem, and this plugin has a documented history
+  // of users objecting to log noise.
+  private consecutiveReviveFailures = 0
+
+  constructor(private readonly opts: ConnectionWatchdogOptions) {}
+
+  public start(): void {
+    if (this.timer) {
+      return
+    }
+    this.stopped = false
+    const interval = this.opts.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS
+    this.timer = setInterval(() => {
+      void this.check()
+    }, interval)
+    // Never hold the process open on shutdown just to ping.
+    this.timer.unref?.()
+  }
+
+  public stop(): void {
+    this.stopped = true
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  private async check(): Promise<void> {
+    if (this.reviving || this.stopped || this.opts.skip?.()) {
+      return
+    }
+
+    const timeoutMs = this.opts.pingTimeoutMs ?? DEFAULT_PING_TIMEOUT_MS
+    const threshold = this.opts.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD
+
+    try {
+      // The extra timeout matters even though lutron-leap's request() has its
+      // own 5s timer: that timer is armed inside the socket.write callback,
+      // so a ping issued against a socket that dies between connect and
+      // write never settles at all. This bound guarantees the watchdog
+      // always gets an answer.
+      await withTimeout(this.opts.ping(), timeoutMs, `watchdog ping to bridge ${this.opts.bridgeLabel} timed out`)
+      if (this.consecutiveFailures > 0) {
+        this.opts.log.info(`Bridge ${this.opts.bridgeLabel} connection recovered after ${this.consecutiveFailures} failed ping(s)`)
+      }
+      this.consecutiveFailures = 0
+      this.consecutiveReviveFailures = 0
+      // Past an await: re-check before doing repair work. A ping resolving
+      // after stop() must not trigger a re-subscribe against a bridge nobody
+      // is listening to, and one resolving mid-reconfigure must not interleave
+      // repair work with the reconfigure that made it moot.
+      if (this.stopped || this.opts.skip?.()) {
+        return
+      }
+      try {
+        await this.opts.onHealthy?.()
+      } catch (e) {
+        // Never let follow-up repair work break the ping loop itself.
+        this.opts.log.debug(`Post-ping repair for bridge ${this.opts.bridgeLabel} failed:`, e)
+      }
+    } catch (e) {
+      // Re-check the guards now that we are past an await. A reconfigure that
+      // started while the ping was in flight calls LeapClient.drain(), which
+      // clears every in-flight request without settling it, so the ping we
+      // just lost says nothing about the health of the new connection.
+      // Counting it would be a false strike against a connection that is
+      // being repaired already.
+      if (this.stopped || this.opts.skip?.()) {
+        return
+      }
+
+      this.consecutiveFailures++
+      this.opts.log.debug(`Watchdog ping ${this.consecutiveFailures}/${threshold} to bridge ${this.opts.bridgeLabel} failed:`, e)
+      if (this.consecutiveFailures < threshold) {
+        return
+      }
+
+      // Quiet the repeated announcements once a bridge has been unreachable
+      // for a while; the first failure of a run is always at warn.
+      const firstAttempt = this.consecutiveReviveFailures === 0
+      const announce = firstAttempt ? this.opts.log.warn.bind(this.opts.log) : this.opts.log.debug.bind(this.opts.log)
+      announce(`LEAP connection to bridge ${this.opts.bridgeLabel} appears stale (${threshold} consecutive failed pings); forcing a reconnect`)
+
+      this.consecutiveFailures = 0
+      this.reviving = true
+      try {
+        const repaired = await this.opts.revive()
+        this.consecutiveReviveFailures = 0
+        if (repaired === false) {
+          this.opts.log.debug(`Bridge ${this.opts.bridgeLabel} repair was already in progress elsewhere; watchdog stood down`)
+        } else {
+          this.opts.log.info(`Bridge ${this.opts.bridgeLabel} connection re-established by watchdog`)
+        }
+      } catch (reviveError) {
+        this.consecutiveReviveFailures++
+        const report = firstAttempt ? this.opts.log.error.bind(this.opts.log) : this.opts.log.debug.bind(this.opts.log)
+        report(`Watchdog failed to re-establish connection to bridge ${this.opts.bridgeLabel}; will keep trying:`, reviveError)
+      } finally {
+        this.reviving = false
+      }
+    }
+  }
+}

--- a/src/OccupancySensorRouter.ts
+++ b/src/OccupancySensorRouter.ts
@@ -86,10 +86,18 @@ export class OccupancySensorRouter {
 
         // when the bridge is disconnected, subscriptions are lost. re-establish them.
         bridge.on('disconnected', () => {
-          bridge.subscribeToOccupancy(_handleOccupancyUpdate.bind(this)).then(_handleGlobalUpdate.bind(this))
-          // WARNING: uncaught throw here will crash the program, but
-          // there's nothing to be done if re-subscribing fails.
-          // better to just blow it all up.
+          bridge.subscribeToOccupancy(_handleOccupancyUpdate.bind(this))
+            .then(_handleGlobalUpdate.bind(this))
+            // Previously uncaught by design ("better to just blow it all up"),
+            // but crashing the child bridge is the #236 failure class: the
+            // restart corrupts the accessory cache and costs users their room
+            // assignments. A failed re-subscribe is now observed and logged on
+            // this file's debug channel (the router is a singleton with no
+            // Homebridge logger), and is retried on the next 'disconnected'
+            // emission.
+            .catch((e) => {
+              logDebug('failed to re-subscribe to occupancy updates after reconnect:', e)
+            })
         })
       }),
     )

--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -481,7 +481,21 @@ export class PicoRemote {
     this.bridge.on('disconnected', () => {
       this.platform.log.debug(`re-subscribing to ${this.buttons.length} button(s) after connection loss`)
       for (const button of this.buttons) {
-        this.bridge.subscribeToButton(button, this.handleEvent.bind(this))
+        // Not subscribeToButton(): that discards the subscribe promise inside
+        // lutron-leap, so a failure (bridge still flaky right after a
+        // reconnect) is both invisible and fatal. The rejection surfaces as
+        // an unhandled rejection, and socket-level errors do not match the
+        // patterns the platform's unhandledRejection handler suppresses, so
+        // it kills the child bridge, which is the #236 class of failure.
+        // Subscribing through the client directly hands us the promise, so a
+        // failed re-subscribe becomes a visible warn instead of a crash.
+        this.bridge.client.subscribe(`${button.href}/status/event`, this.handleEvent.bind(this))
+          .catch((e: unknown) => {
+            this.platform.log.warn(
+              `Failed to re-subscribe ${button.href} after reconnect; this button will stay silent until the next reconnect:`,
+              e,
+            )
+          })
       }
     })
 

--- a/src/Platform.HAP.test.ts
+++ b/src/Platform.HAP.test.ts
@@ -1,0 +1,492 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// lutron-leap opens real sockets and starts real mDNS discovery on import, so
+// the whole module is replaced. The doubles below model only the behaviour the
+// platform depends on, including the two library quirks this file exists to
+// pin down: reconfigureBridge() sets bridgeReconfigInProgress with no
+// try/finally, and it drains the old client (destroying every subscription)
+// before it attempts to connect.
+const { LeapClientMock, SmartBridgeMock, BridgeFinderMock } = vi.hoisted(() => {
+  // Defined inline rather than extending node's EventEmitter: vi.hoisted runs
+  // before this module's imports are initialised.
+  class TinyEmitter {
+    private handlers = new Map<string, Array<(...args: any[]) => void>>()
+    on(event: string, cb: (...args: any[]) => void) {
+      const list = this.handlers.get(event) ?? []
+      list.push(cb)
+      this.handlers.set(event, list)
+      return this
+    }
+
+    removeListener(event: string, cb: (...args: any[]) => void) {
+      const list = (this.handlers.get(event) ?? []).filter(h => h !== cb)
+      this.handlers.set(event, list)
+      return this
+    }
+
+    emit(event: string, ...args: any[]) {
+      for (const cb of [...(this.handlers.get(event) ?? [])]) {
+        cb(...args)
+      }
+      return true
+    }
+
+    setMaxListeners() {
+      return this
+    }
+  }
+
+  class LeapClientMock {
+    public static instances: LeapClientMock[] = []
+    // Static so a test can change connect behaviour for clients the platform
+    // has not built yet. An instance field would be shadowed per instance.
+    public static connectImpl: () => Promise<void> = async () => {}
+    public closed = false
+    constructor(public host: string) {
+      LeapClientMock.instances.push(this)
+    }
+
+    connect() {
+      return LeapClientMock.connectImpl()
+    }
+
+    close() {
+      this.closed = true
+    }
+  }
+
+  class SmartBridgeMock extends TinyEmitter {
+    public bridgeReconfigInProgress = false
+    public pingLooper: any = null
+    public reconfigureImpl: () => Promise<void> = async () => {}
+    public pingImpl: () => Promise<unknown> = async () => ({})
+    public getDeviceInfoImpl: () => Promise<any[]> = async () => []
+    public reconfigureCalls = 0
+    constructor(public bridgeID: string, public client: any) {
+      super()
+    }
+
+    async reconfigureBridge(newClient: any) {
+      this.reconfigureCalls++
+      // Mirrors the library: flag set on entry, old client drained, and only
+      // then the connect attempt that may throw.
+      this.bridgeReconfigInProgress = true
+      this.client = newClient
+      await this.reconfigureImpl()
+      this.emit('disconnected')
+      this.bridgeReconfigInProgress = false
+    }
+
+    ping() {
+      return this.pingImpl()
+    }
+
+    getDeviceInfo() {
+      return this.getDeviceInfoImpl()
+    }
+  }
+
+  class BridgeFinderMock extends TinyEmitter {
+    beginSearching() {}
+  }
+
+  return { LeapClientMock, SmartBridgeMock, BridgeFinderMock }
+})
+
+vi.mock('lutron-leap', () => ({
+  BridgeFinder: BridgeFinderMock,
+  LeapClient: LeapClientMock,
+  SmartBridge: SmartBridgeMock,
+  LEAP_PORT: 8081,
+  ExceptionDetail: class ExceptionDetail {},
+}))
+
+const { LutronCasetaLeap } = await import('./Platform.HAP.js')
+const { LutronCasetaLeapMatterPlatform } = await import('./Platform.Matter.js')
+
+function makeLog(): any {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), success: vi.fn(), log: vi.fn() }
+}
+
+function makeApi(): any {
+  return {
+    on: vi.fn(),
+    hap: { uuid: { generate: (s: string) => `uuid-${s}` } },
+    platformAccessory: class {},
+  }
+}
+
+const SECRET = { bridgeid: 'ABC123', ca: 'ca', key: 'key', cert: 'cert' }
+
+function makePlatform() {
+  const log = makeLog()
+  const api = makeApi()
+  const platform: any = new LutronCasetaLeap(log, { platform: 'LutronCasetaLeap', secrets: [SECRET] } as any, api)
+  // Device scanning is exercised separately; stub it out so discovery tests do
+  // not depend on the whole wiring pipeline.
+  platform.processAllDevices = vi.fn()
+  return { platform, log, api }
+}
+
+const announce = { bridgeid: 'ABC123', ipAddr: '192.168.1.50', systype: 'SmartBridge' } as any
+
+// Each platform instance registers process-level 'warning' and 'SIGUSR2'
+// handlers. Production creates one; this file creates a dozen, which trips
+// node's default listener cap and prints a spurious leak warning in CI.
+process.setMaxListeners(0)
+
+beforeEach(() => {
+  LeapClientMock.instances.length = 0
+  LeapClientMock.connectImpl = async () => {}
+})
+
+// Restore real timers globally: a test that fails before its own cleanup would
+// otherwise leave fake timers installed and hang every test after it.
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('platform bridge discovery and watchdog wiring', () => {
+  it('creates exactly one watchdog per bridge across repeated announces', async () => {
+    const { platform } = makePlatform()
+    await platform.handleBridgeDiscovery(announce)
+    const first = platform.watchdogs.get('abc123')
+    expect(first).toBeDefined()
+
+    await platform.handleBridgeDiscovery(announce)
+    expect(platform.watchdogs.size).toBe(1)
+    expect(platform.watchdogs.get('abc123')).toBe(first)
+    first.stop()
+  })
+
+  it('records a newly announced address even while a reconfigure is in flight', async () => {
+    // Regression test. BridgeFinder only emits on an absent-to-present
+    // transition, so a dropped announce is usually the only one carrying a new
+    // DHCP address. Returning early without recording it left the watchdog
+    // rebuilding clients for a dead address forever.
+    const { platform } = makePlatform()
+    await platform.handleBridgeDiscovery(announce)
+    platform.watchdogs.get('abc123').stop()
+
+    platform.bridgeMgr.get('abc123').bridgeReconfigInProgress = true
+    await platform.handleBridgeDiscovery({ ...announce, ipAddr: '192.168.1.77' })
+
+    expect(platform.bridgeAddrs.get('abc123')).toBe('192.168.1.77')
+  })
+
+  it('a failed reconfigure on the mDNS path clears the flag and does not reject', async () => {
+    const { platform, log } = makePlatform()
+    await platform.handleBridgeDiscovery(announce)
+    platform.watchdogs.get('abc123').stop()
+
+    const bridge = platform.bridgeMgr.get('abc123')
+    bridge.reconfigureImpl = async () => {
+      throw new Error('bridge unreachable')
+    }
+
+    // Must not reject: this runs as an mDNS event handler with no caller, and
+    // an escaping rejection is the #236 crash.
+    await expect(platform.handleBridgeDiscovery(announce)).resolves.toBeUndefined()
+    expect(bridge.bridgeReconfigInProgress).toBe(false)
+    expect(platform.bridgesNeedingResubscribe.has('abc123')).toBe(true)
+    expect(log.error).toHaveBeenCalled()
+  })
+})
+
+describe('reviveBridge', () => {
+  beforeEach(() => {
+    LeapClientMock.instances.length = 0
+  })
+
+  async function setup() {
+    const ctx = makePlatform()
+    await ctx.platform.handleBridgeDiscovery(announce)
+    ctx.platform.watchdogs.get('abc123').stop()
+    return { ...ctx, bridge: ctx.platform.bridgeMgr.get('abc123') }
+  }
+
+  it('rebuilds a client for the last known address and reconfigures the bridge', async () => {
+    const { platform, bridge } = await setup()
+    platform.bridgeAddrs.set('abc123', '192.168.1.77')
+
+    await platform.reviveBridge('abc123')
+
+    expect(LeapClientMock.instances.at(-1)!.host).toBe('192.168.1.77')
+    expect(bridge.reconfigureCalls).toBe(1)
+    expect(bridge.bridgeReconfigInProgress).toBe(false)
+  })
+
+  it('gives up without touching the live connection when the bridge is unreachable', async () => {
+    // The critical property: a repair that cannot connect must NOT call
+    // reconfigureBridge, because that would drain the working client's
+    // subscriptions and then block every recovery path while it retried.
+    const { platform, bridge } = await setup()
+    vi.useFakeTimers()
+    LeapClientMock.connectImpl = () => new Promise(() => {})
+
+    const attempt = platform.reviveBridge('abc123')
+    const assertion = expect(attempt).rejects.toThrow(/cannot reach bridge/)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await assertion
+
+    expect(bridge.reconfigureCalls).toBe(0)
+    expect(bridge.bridgeReconfigInProgress).toBe(false)
+    expect(LeapClientMock.instances.at(-1)!.closed).toBe(true)
+  })
+
+  it('stands down when an mDNS reconfigure starts during the pre-connect window', async () => {
+    // Regression test for the final-gate blocker. A bridge recovering from a
+    // power cycle starts accepting TLS at the same moment it mDNS-announces,
+    // so the announce path can enter reconfigureBridge() while the watchdog's
+    // pre-connect is awaiting. Proceeding would run two reconfigures: two
+    // 'disconnected' emissions, two subscriptions per button, every press
+    // delivered twice, and the press/release tracker reset by Press,Press,
+    // which reads as dead Picos, the exact symptom being fixed.
+    const { platform, bridge } = await setup()
+    LeapClientMock.connectImpl = async () => {
+      // Simulates handleBridgeDiscovery entering reconfigureBridge() while
+      // the watchdog's pre-connect is in flight.
+      bridge.bridgeReconfigInProgress = true
+    }
+
+    await platform.reviveBridge('abc123')
+
+    expect(bridge.reconfigureCalls).toBe(0)
+    expect(LeapClientMock.instances.at(-1)!.closed).toBe(true)
+  })
+
+  it('marks the bridge for re-subscription when the reconfigure itself fails', async () => {
+    const { platform, bridge } = await setup()
+    bridge.reconfigureImpl = async () => {
+      throw new Error('dropped mid-reconfigure')
+    }
+
+    await expect(platform.reviveBridge('abc123')).rejects.toThrow('dropped mid-reconfigure')
+    // Flag reset by hand because the library leaves it stuck true.
+    expect(bridge.bridgeReconfigInProgress).toBe(false)
+    expect(platform.bridgesNeedingResubscribe.has('abc123')).toBe(true)
+  })
+
+  it('re-subscribes on the next healthy ping after an interrupted repair', async () => {
+    const { platform, bridge } = await setup()
+    platform.bridgesNeedingResubscribe.add('abc123')
+    const onDisconnected = vi.fn()
+    bridge.on('disconnected', onDisconnected)
+
+    await platform.resubscribeIfNeeded('abc123')
+
+    expect(onDisconnected).toHaveBeenCalledTimes(1)
+    expect(platform.bridgesNeedingResubscribe.has('abc123')).toBe(false)
+  })
+
+  it('does nothing on a healthy ping when no repair is outstanding', async () => {
+    const { platform, bridge } = await setup()
+    const onDisconnected = vi.fn()
+    bridge.on('disconnected', onDisconnected)
+
+    await platform.resubscribeIfNeeded('abc123')
+
+    expect(onDisconnected).not.toHaveBeenCalled()
+  })
+
+  it('does not re-subscribe twice when the socket already reconnected on its own', async () => {
+    // Regression guard. PicoRemote re-subscribes every button on each
+    // 'disconnected', so two emissions leave two subscriptions per button:
+    // every press is delivered twice and the press/release state machine
+    // desynchronises. A natural reconnect satisfies the outstanding repair.
+    const { platform, bridge } = await setup()
+    platform.bridgesNeedingResubscribe.add('abc123')
+
+    // The library emits this by itself when a socket closes and reopens.
+    bridge.emit('disconnected')
+    expect(platform.bridgesNeedingResubscribe.has('abc123')).toBe(false)
+
+    const afterNaturalReconnect = vi.fn()
+    bridge.on('disconnected', afterNaturalReconnect)
+    await platform.resubscribeIfNeeded('abc123')
+    expect(afterNaturalReconnect).not.toHaveBeenCalled()
+  })
+})
+
+describe('accessory identity across a repair', () => {
+  // The #169 / #236 symptom was Picos reappearing as new HomeKit accessories
+  // and losing their room assignments and automations. These pin down that a
+  // watchdog repair cannot do that.
+  const pico = {
+    SerialNumber: 12345,
+    DeviceType: 'Pico2Button',
+    FullyQualifiedName: ['Kitchen', 'Pico'],
+    ModelNumber: 'PJ2-2B',
+  } as any
+
+  async function setupWithCachedPico() {
+    const ctx = makePlatform()
+    // Simulate Homebridge restoring the accessory from its cache at startup.
+    const cached: any = { UUID: 'uuid-12345', displayName: 'Kitchen Pico', context: {}, services: [] }
+    ctx.platform.configureAccessory(cached)
+    // Real wiring needs HAP services; assert on registration bookkeeping only.
+    ctx.platform.wireAccessory = vi.fn(async () => ({ kind: 0, name: 'Kitchen Pico' }))
+    return { ...ctx, cached }
+  }
+
+  it('reuses the cached accessory instead of registering a new one', async () => {
+    const { platform, api, cached } = await setupWithCachedPico()
+    api.registerPlatformAccessories = vi.fn()
+    api.unregisterPlatformAccessories = vi.fn()
+    const bridge = new SmartBridgeMock('abc123', {})
+
+    // Repeat the wiring the way repeated repairs would.
+    await platform.processDevice(bridge, pico)
+    await platform.processDevice(bridge, pico)
+
+    expect(api.registerPlatformAccessories).not.toHaveBeenCalled()
+    expect(api.unregisterPlatformAccessories).not.toHaveBeenCalled()
+    expect(platform.accessories.size).toBe(1)
+    expect(platform.accessories.get('uuid-12345')).toBe(cached)
+  })
+
+  it('skips already-wired devices on a repair rescan, so initialize never runs twice', async () => {
+    const { platform, api } = await setupWithCachedPico()
+    api.registerPlatformAccessories = vi.fn()
+    const bridge = new SmartBridgeMock('abc123', {})
+    bridge.getDeviceInfoImpl = async () => [pico]
+
+    await platform.processDevice(bridge, pico)
+    expect(platform.wiredDevices.has('uuid-12345')).toBe(true)
+
+    // A repair calls processAllDevices(); the wired device must be filtered
+    // out so its 'disconnected' and 'unsolicited' listeners cannot accumulate.
+    // Use the real implementation, not the stub makePlatform() installs.
+    platform.processAllDevices = Object.getPrototypeOf(platform).processAllDevices.bind(platform)
+    ;(platform.wireAccessory as any).mockClear()
+    platform.processAllDevices(bridge)
+    await vi.waitFor(() => expect(platform.activeScanBridges.size).toBe(0))
+
+    expect(platform.wireAccessory).not.toHaveBeenCalled()
+    expect(api.registerPlatformAccessories).not.toHaveBeenCalled()
+  })
+})
+
+describe('getDeviceInfoWithRetry', () => {
+  it('rejects rather than hanging when getDeviceInfo never settles', async () => {
+    // lutron-leap arms its request timeout inside the socket.write callback,
+    // so a request against a dead socket can hang forever. Unbounded, that
+    // leaves the bridge in activeScanBridges and disables all later scans.
+    vi.useFakeTimers()
+    const { platform } = makePlatform()
+    const bridge = new SmartBridgeMock('abc123', {})
+    bridge.getDeviceInfoImpl = () => new Promise(() => {})
+
+    const attempt = platform.getDeviceInfoWithRetry(bridge)
+    const assertion = expect(attempt).rejects.toThrow(/timed out/)
+    // 4 attempts each bounded at 60s, with 5s/15s/45s waits between them: 305s
+    // in total, so advance comfortably past that.
+    await vi.advanceTimersByTimeAsync(400_000)
+    await assertion
+    vi.useRealTimers()
+  })
+})
+
+describe('matter platform cached-accessory preservation', () => {
+  // The Matter override used to unregister cached accessories on Error and on
+  // generic Skipped, the exact #207 bug the HAP path fixed. Watchdog repairs
+  // rescan during flaky windows, when transient wire errors are most likely,
+  // so the purge path must be closed before the watchdog ships.
+  const pico = {
+    SerialNumber: 12345,
+    DeviceType: 'Pico2Button',
+    FullyQualifiedName: ['Kitchen', 'Pico'],
+    ModelNumber: 'PJ2-2B',
+  } as any
+
+  function makeMatterPlatform() {
+    const log = makeLog()
+    const api = makeApi()
+    api.matter = {
+      registerPlatformAccessories: vi.fn(),
+      unregisterPlatformAccessories: vi.fn(),
+      deviceTypes: { BridgedNode: {}, GenericSwitch: {} },
+    }
+    api.unregisterPlatformAccessories = vi.fn()
+    const platform: any = new LutronCasetaLeapMatterPlatform(
+      log,
+      { platform: 'LutronCasetaLeap', secrets: [SECRET] } as any,
+      api,
+    )
+    // context.device is normally stamped by wireAccessory; the stubbed wire
+    // skips that, but getMatterClusters reads it when building Pico parts.
+    const cached: any = { UUID: 'uuid-12345', displayName: 'Kitchen Pico', context: { device: pico }, services: [] }
+    platform.configureAccessory(cached)
+    return { platform, api, cached }
+  }
+
+  it('leaves a cached accessory registered when wiring errors during a rescan', async () => {
+    const { platform, api } = makeMatterPlatform()
+    platform.wireAccessory = vi.fn(async () => ({ kind: 2, reason: 'transient bridge error' }))
+    const bridge = new SmartBridgeMock('abc123', {})
+
+    await expect(platform.processDevice(bridge, pico)).resolves.toMatch(/leaving cached matter accessory registered/i)
+    expect(api.matter.unregisterPlatformAccessories).not.toHaveBeenCalled()
+  })
+
+  it('leaves a cached accessory registered on a transient skip', async () => {
+    const { platform, api } = makeMatterPlatform()
+    platform.wireAccessory = vi.fn(async () => ({ kind: 1, reason: 'bridge response missing AffectedZones' }))
+    const bridge = new SmartBridgeMock('abc123', {})
+
+    await expect(platform.processDevice(bridge, pico)).resolves.toMatch(/leaving cached matter accessory registered/i)
+    expect(api.matter.unregisterPlatformAccessories).not.toHaveBeenCalled()
+  })
+
+  it('still unregisters a cached accessory for an explicitly excluded device type', async () => {
+    const { platform, api } = makeMatterPlatform()
+    platform.wireAccessory = vi.fn(async () => ({ kind: 1, reason: 'Device type excluded by config: Pico2Button' }))
+    const bridge = new SmartBridgeMock('abc123', {})
+
+    await platform.processDevice(bridge, pico)
+    // Deliberate removals purge both registries.
+    expect(api.matter.unregisterPlatformAccessories).toHaveBeenCalledTimes(1)
+    expect(api.unregisterPlatformAccessories).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('in-flight wiring guard', () => {
+  it('does not wire the same device twice while a slow wire is still in flight', async () => {
+    // The scan timeout bounds the SCAN, not the wiring: a processDevice that
+    // outlives DEVICE_WIRE_TIMEOUT_MS is still running when the next scan
+    // starts. Wiring it again would create two PicoRemote instances and
+    // deliver every press twice.
+    vi.useFakeTimers()
+    const { platform } = makePlatform()
+    const pico = {
+      SerialNumber: 12345,
+      DeviceType: 'Pico2Button',
+      FullyQualifiedName: ['Kitchen', 'Pico'],
+      ModelNumber: 'PJ2-2B',
+    } as any
+    const bridge = new SmartBridgeMock('abc123', {})
+    bridge.getDeviceInfoImpl = async () => [pico]
+    platform.processDevice = vi.fn(() => new Promise(() => { /* wiring never finishes */ }))
+    platform.processAllDevices = Object.getPrototypeOf(platform).processAllDevices.bind(platform)
+
+    platform.processAllDevices(bridge)
+    await vi.advanceTimersByTimeAsync(61_000)
+    await vi.waitFor(() => expect(platform.activeScanBridges.size).toBe(0))
+    expect(platform.processDevice).toHaveBeenCalledTimes(1)
+
+    platform.processAllDevices(bridge)
+    await vi.advanceTimersByTimeAsync(61_000)
+    await vi.waitFor(() => expect(platform.activeScanBridges.size).toBe(0))
+    expect(platform.processDevice).toHaveBeenCalledTimes(1)
+
+    // A claim held only by a promise that can never settle (e.g. a request
+    // stranded by drain(), whose resolver was dropped) must not exclude the
+    // device forever. After the TTL the device becomes retryable again.
+    await vi.advanceTimersByTimeAsync(200_000)
+    platform.processAllDevices(bridge)
+    await vi.advanceTimersByTimeAsync(61_000)
+    await vi.waitFor(() => expect(platform.activeScanBridges.size).toBe(0))
+    expect(platform.processDevice).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+})

--- a/src/Platform.HAP.ts
+++ b/src/Platform.HAP.ts
@@ -22,16 +22,39 @@ import {
   SmartBridge,
 } from 'lutron-leap'
 
+import { ConnectionWatchdog } from './ConnectionWatchdog.js'
 import { createFilteredLogger } from './Logger.js'
 import { OccupancySensor } from './OccupancySensor.js'
 import { PicoRemote } from './PicoRemote.js'
 import { SerenaTiltOnlyWoodBlinds } from './SerenaTiltOnlyWoodBlinds.js'
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js'
+import { withTimeout } from './utils.js'
 
 interface PlatformEvents {
   [event: string]: (...args: any[]) => void
   unsolicited: (response: Response) => void
 }
+
+// How long a watchdog repair waits for a TLS connection before giving up and
+// retrying on the next cycle. Deliberately short: a repair that cannot connect
+// quickly should fail fast and leave the existing connection alone rather than
+// tearing it down and blocking every other recovery path while it retries.
+const REVIVE_CONNECT_TIMEOUT_MS = 10_000
+// Upper bound on wiring a single device. Without it, one LEAP request that
+// never settles (see the comment on getDeviceInfoWithRetry) strands
+// Promise.allSettled and leaves the bridge in activeScanBridges forever,
+// silently disabling all later scans.
+const DEVICE_WIRE_TIMEOUT_MS = 60_000
+// A wiringDevices claim normally releases when the wiring settles, but a
+// wiring stranded by drain() can NEVER settle: drain() clears the in-flight
+// map without rejecting, dropping the only reference to the promise's
+// resolver. A claim held solely by such a promise would exclude the device
+// from every future scan until restart, so claims also expire. Expiry is
+// safe: a wire hung that way has no remaining path to completion, so it can
+// never race a later retry, and a genuinely slow-but-alive wire finishes far
+// inside this bound (the library caps each armed request at 5s, and a device
+// wires with at most a couple dozen requests).
+const WIRING_CLAIM_TTL_MS = 3 * DEVICE_WIRE_TIMEOUT_MS
 
 // see config.schema.json
 export interface GlobalOptions {
@@ -94,6 +117,25 @@ export class LutronCasetaLeap
   private options: GlobalOptions
   private secrets: Map<string, BridgeAuthEntry>
   private bridgeMgr: Map<string, SmartBridge> = new Map()
+  // Last known IP address per bridge, refreshed on every mDNS announce. The
+  // watchdog uses it to rebuild a client when the connection has gone stale
+  // and no fresh announce is available to supply an address.
+  private bridgeAddrs: Map<string, string> = new Map()
+  // One ConnectionWatchdog per bridge; see ConnectionWatchdog.ts for why the
+  // plugin needs its own staleness repair on top of lutron-leap's ping loop.
+  private watchdogs: Map<string, ConnectionWatchdog> = new Map()
+  // Bridges whose LEAP subscriptions were destroyed by a reconfigure that then
+  // failed to reconnect. They must be re-subscribed once the bridge answers
+  // again, because a reachable bridge with no subscriptions looks healthy to a
+  // ping while delivering no button or occupancy events at all.
+  private bridgesNeedingResubscribe: Set<string> = new Set()
+  // Devices whose processDevice() is currently in flight: accessory UUID to
+  // the claim timestamp. See the filter in processAllDevices() and the
+  // WIRING_CLAIM_TTL_MS comment for why claims expire.
+  private wiringDevices: Map<string, number> = new Map()
+  // TLS keylog streams, one per bridge, kept so rebuilding a client does not
+  // leak a file handle each time. Only populated when logSSLKeyDangerous is on.
+  private keylogStreams: Map<string, fs.WriteStream> = new Map()
   // Log is declared as a regular field rather than a constructor parameter
   // property because we need to wrap it (with the user's logLevel filter)
   // before the rest of the constructor — and parameter properties are
@@ -215,6 +257,16 @@ export class LutronCasetaLeap
       this.finder.beginSearching()
     })
 
+    api.on(APIEvent.SHUTDOWN, () => {
+      // Stop pinging on the way out. The intervals are unref'd so they cannot
+      // hold the process open by themselves, but a repair started during
+      // shutdown would keep opening sockets against a bridge nobody is
+      // listening to any more.
+      for (const watchdog of this.watchdogs.values()) {
+        watchdog.stop()
+      }
+    })
+
     process.on('SIGUSR2', () => {
       const fileName = `/tmp/lutron.${Date.now()}.heapsnapshot`
       const usage = process.memoryUsage()
@@ -291,6 +343,16 @@ export class LutronCasetaLeap
     let replaceClient = false
     const bridgeID = bridgeInfo.bridgeid.toLowerCase()
 
+    // Record the address before any early return below. BridgeFinder only
+    // emits 'discovered' on an absent-to-present transition, so an announce
+    // dropped here is usually the ONLY one that will ever carry a new DHCP
+    // address. Returning early without recording it would leave the watchdog
+    // rebuilding clients for an address the bridge no longer has, which is the
+    // exact permanent-wedge this watchdog exists to prevent.
+    if (this.secrets.has(bridgeID)) {
+      this.bridgeAddrs.set(bridgeID, bridgeInfo.ipAddr)
+    }
+
     if (this.bridgeMgr.has(bridgeID)) {
       // this is an existing bridge re-announcing itself, so we'll recycle the connection to it
       if (this.bridgeMgr.get(bridgeID)!.bridgeReconfigInProgress === true) {
@@ -307,15 +369,9 @@ export class LutronCasetaLeap
     }
 
     if (this.secrets.has(bridgeID)) {
-      const these = this.secrets.get(bridgeID)!
-      this.log.debug('bridge', bridgeInfo.bridgeid, 'has secrets', JSON.stringify(these))
+      this.log.debug('bridge', bridgeInfo.bridgeid, 'has secrets configured')
 
-      let logfile: fs.WriteStream | undefined
-      if (this.options.logSSLKeyDangerous) {
-        logfile = fs.createWriteStream(`/tmp/${bridgeInfo.bridgeid}-tlskey.log`, { flags: 'a' })
-      }
-
-      const client = new LeapClient(bridgeInfo.ipAddr, LEAP_PORT, these.ca, these.key, these.cert, logfile)
+      const client = this.createLeapClient(bridgeID, bridgeInfo.ipAddr)
 
       if (replaceClient) {
         // when we close the client connection, it disconnects, which
@@ -346,7 +402,30 @@ export class LutronCasetaLeap
         // Bookend an internal reconfigure operation. Useful when debugging
         // a reconfigure issue, but normal-path noise otherwise. info → debug.
         this.log.debug('Bridge', bridgeInfo.bridgeid, 'entering reconfiguration')
-        await this.bridgeMgr.get(bridgeID)!.reconfigureBridge(client)
+        this.clearLibraryPingLoop(this.bridgeMgr.get(bridgeID)!)
+        try {
+          await this.bridgeMgr.get(bridgeID)!.reconfigureBridge(client)
+        } catch (e) {
+          // Swallowing this error is deliberate: it runs as an mDNS event
+          // handler with no caller to catch it, and letting it escape is the
+          // #236 class of failure (an unhandled rejection kills the child
+          // bridge and corrupts the accessory cache). Swallowing it is also
+          // exactly why the flag below must be reset by hand.
+          //
+          // reconfigureBridge() sets bridgeReconfigInProgress with no
+          // try/finally, so a throw leaves it stuck true. Left set, it turns
+          // every future mDNS announce into a no-op and makes the watchdog
+          // skip its pings, wedging the connection until Homebridge restarts.
+          this.bridgeMgr.get(bridgeID)!.bridgeReconfigInProgress = false
+          // drain() already cleared every LEAP subscription before the connect
+          // failed, so the bridge is now subscription-less even if the socket
+          // later comes back on its own. Mark it so the watchdog re-subscribes
+          // as soon as the bridge answers again.
+          this.bridgesNeedingResubscribe.add(bridgeID)
+          this.log.error('Bridge', bridgeInfo.bridgeid, 'reconfiguration failed; will retry on the next announce or watchdog pass:', e)
+          return
+        }
+        this.bridgesNeedingResubscribe.delete(bridgeID)
         this.log.debug('Bridge', bridgeInfo.bridgeid, 'exit reconfiguration')
         // reconfigureBridge() emits 'disconnected' so already-wired devices
         // re-subscribe via their own handlers. Call processAllDevices() to
@@ -361,15 +440,181 @@ export class LutronCasetaLeap
         // see [#123](https://github.com/homebridge-plugins/homebridge-lutron/issues/123)
         bridge.setMaxListeners(400)
 
+        // Any 'disconnected' emission, from whatever source, makes every
+        // device re-subscribe through its own handler, so an outstanding
+        // repair is satisfied by it. Clearing the flag here is what stops
+        // resubscribeIfNeeded() emitting a SECOND time: PicoRemote
+        // re-subscribes all of its buttons unconditionally, so a redundant
+        // emission would leave two subscriptions per button, deliver every
+        // press twice, and desynchronise the press/release state machine.
+        bridge.on('disconnected', () => {
+          this.bridgesNeedingResubscribe.delete(bridgeID)
+        })
+
         this.bridgeMgr.set(bridge.bridgeID, bridge)
         this.processAllDevices(bridge)
       }
+      this.ensureWatchdog(bridgeID)
     } else {
       // Multi-bridge scenario noise — if the user has 2 bridges and only
       // configured 1, the unconfigured one will hit this branch on every
       // mDNS announce. info → debug.
       this.log.debug('no credentials from bridge ID', bridgeInfo.bridgeid)
     }
+  }
+
+  private createLeapClient(bridgeID: string, ipAddr: string): LeapClient {
+    const these = this.secrets.get(bridgeID)!
+    let logfile: fs.WriteStream | undefined
+    if (this.options.logSSLKeyDangerous) {
+      // Cached per bridge rather than per client. A client is rebuilt on every
+      // mDNS re-announce and on every watchdog repair, so creating a stream
+      // here would leak a file handle each time.
+      logfile = this.keylogStreams.get(bridgeID)
+      if (!logfile) {
+        logfile = fs.createWriteStream(`/tmp/${these.bridgeid}-tlskey.log`, { flags: 'a' })
+        logfile.on('error', e => this.log.warn(`TLS keylog stream for ${these.bridgeid} failed:`, e))
+        this.keylogStreams.set(bridgeID, logfile)
+      }
+    }
+    return new LeapClient(ipAddr, LEAP_PORT, these.ca, these.key, these.cert, logfile)
+  }
+
+  // reconfigureBridge() drops its reference to the running ping interval
+  // (`this.pingLooper = null`) without clearing it, so every reconfigure
+  // orphans a timer that keeps pinging every 5 minutes for the life of the
+  // process. Clear it before handing over a new client. Reaching into a
+  // private field is deliberate; bridge.close() is not usable here because it
+  // re-emits 'disconnected', which would make every device re-subscribe
+  // against the client we are about to discard.
+  private clearLibraryPingLoop(bridge: SmartBridge): void {
+    const looper = (bridge as unknown as { pingLooper: ReturnType<typeof setInterval> | null }).pingLooper
+    if (looper) {
+      clearInterval(looper)
+    }
+  }
+
+  private ensureWatchdog(bridgeID: string): void {
+    if (this.watchdogs.has(bridgeID)) {
+      return
+    }
+    const watchdog = new ConnectionWatchdog({
+      bridgeLabel: bridgeID,
+      ping: () => this.bridgeMgr.get(bridgeID)!.ping(),
+      revive: () => this.reviveBridge(bridgeID),
+      skip: () => this.bridgeMgr.get(bridgeID)?.bridgeReconfigInProgress === true,
+      onHealthy: () => this.resubscribeIfNeeded(bridgeID),
+      log: this.log,
+    })
+    watchdog.start()
+    this.watchdogs.set(bridgeID, watchdog)
+  }
+
+  // A ping proving the bridge answers is NOT the same as the plugin working.
+  // lutron-leap's request() awaits connect(), so a ping silently opens a new
+  // socket, and LeapClient._empty() cleared every subscription when the old
+  // one closed. Without this, a repair that died partway would leave a
+  // reachable bridge whose button presses and occupancy events never arrive,
+  // and the watchdog would report it healthy forever.
+  private async resubscribeIfNeeded(bridgeID: string): Promise<void> {
+    if (!this.bridgesNeedingResubscribe.has(bridgeID)) {
+      return
+    }
+    const bridge = this.bridgeMgr.get(bridgeID)
+    if (!bridge || bridge.bridgeReconfigInProgress) {
+      return
+    }
+    this.bridgesNeedingResubscribe.delete(bridgeID)
+    this.log.info(`Bridge ${bridgeID} is answering again after an interrupted repair; re-subscribing devices`)
+    // PicoRemote and OccupancySensorRouter both listen for 'disconnected' and
+    // re-subscribe over bridge.client, which by now is the reconnected one.
+    bridge.emit('disconnected')
+    this.processAllDevices(bridge)
+  }
+
+  // Called by the per-bridge ConnectionWatchdog after consecutive ping
+  // failures. Mirrors the mDNS re-announce path: build a fresh client for
+  // the last known address and run it through reconfigureBridge(), which
+  // reconnects and emits 'disconnected' so devices re-subscribe at the LEAP
+  // layer. This exists because lutron-leap detects dead connections (its
+  // ping loop) but deliberately never repairs them, and mDNS re-announces
+  // are best-effort; without it, a half-open socket (router reboot, Wi-Fi
+  // blip) stays stale until Homebridge restarts.
+  // Returns true when this call performed the repair, false when it stood
+  // down because a reconfigure was already in progress; the watchdog uses
+  // the distinction to keep its success log line truthful.
+  private async reviveBridge(bridgeID: string): Promise<boolean> {
+    const bridge = this.bridgeMgr.get(bridgeID)
+    const ipAddr = this.bridgeAddrs.get(bridgeID)
+    if (!bridge || !ipAddr || !this.secrets.has(bridgeID)) {
+      throw new Error(`cannot revive bridge ${bridgeID}: no known address or credentials`)
+    }
+    if (bridge.bridgeReconfigInProgress) {
+      // The mDNS path is already replacing the client; nothing to do.
+      return false
+    }
+    const client = this.createLeapClient(bridgeID, ipAddr)
+
+    // Prove the bridge is reachable BEFORE handing the client to
+    // reconfigureBridge(). That call is not cancellable and not bounded: it
+    // drains the old client (destroying every subscription) and then retries
+    // connect up to 21 times, and tls.connect() is created with no timeout, so
+    // against a powered-off bridge it can sit for tens of minutes. For that
+    // entire window bridgeReconfigInProgress is true, which suppresses the
+    // watchdog and makes every mDNS announce a no-op: one hung repair would
+    // disable every recovery path the plugin has.
+    //
+    // Connecting first also makes the repair cheap when it fails. connect()
+    // memoises into LeapClient.connected, so reconfigureBridge() then succeeds
+    // on its first retry, and if we never get here the old client is left
+    // untouched with its subscriptions intact.
+    try {
+      await withTimeout(client.connect(), REVIVE_CONNECT_TIMEOUT_MS, `connection to bridge ${bridgeID} at ${ipAddr} timed out`)
+    } catch (e) {
+      // Discard the half-built client. A stalled TLS handshake leaves
+      // LeapClient.connected holding a promise that never settles, and every
+      // later connect() on that instance would return the same dead promise.
+      client.close()
+      throw new Error(`cannot reach bridge ${bridgeID} at ${ipAddr}: ${e}`)
+    }
+
+    // Re-check the guard now that we are past an await. A bridge recovering
+    // from a power cycle starts accepting TLS at the same moment it fires its
+    // absent-to-present mDNS announce, so the announce path can enter
+    // reconfigureBridge() while our pre-connect is in flight. Proceeding here
+    // would run two reconfigures on one bridge: 'disconnected' emitted twice,
+    // every button subscribed twice, every press delivered twice, and the
+    // press/release state machine reset by the invalid Press,Press sequence,
+    // which is precisely the dead-Pico symptom this watchdog exists to fix.
+    // The mDNS path sets the flag synchronously before its first await and
+    // there are no awaits between this check and our reconfigureBridge()
+    // call, so this closes the window completely.
+    if (bridge.bridgeReconfigInProgress) {
+      client.close()
+      this.log.debug(`Bridge ${bridgeID} reconfiguration started while the watchdog was connecting; standing down`)
+      return false
+    }
+
+    this.clearLibraryPingLoop(bridge)
+    try {
+      await bridge.reconfigureBridge(client)
+    } catch (e) {
+      // Same stuck-flag hazard as in handleBridgeDiscovery(): a failed
+      // reconfigure leaves bridgeReconfigInProgress true, which would block
+      // every future repair attempt. Reset it before propagating.
+      bridge.bridgeReconfigInProgress = false
+      // drain() runs before the connect retry, so the subscriptions are
+      // already gone even though the repair failed. Record that so the next
+      // successful ping re-subscribes rather than reporting a healthy bridge
+      // that silently delivers no events.
+      this.bridgesNeedingResubscribe.add(bridgeID)
+      throw e
+    }
+    this.bridgesNeedingResubscribe.delete(bridgeID)
+    // Retry any devices whose initialize() never completed; already-wired
+    // devices re-subscribed via the 'disconnected' event during reconfigure.
+    this.processAllDevices(bridge)
+    return true
   }
 
   // Wrap getDeviceInfo() with bounded exponential backoff. The plain bridge call
@@ -389,7 +634,13 @@ export class LutronCasetaLeap
         await new Promise(resolve => setTimeout(resolve, delay))
       }
       try {
-        return await bridge.getDeviceInfo()
+        // Bounded because lutron-leap's request() only arms its 5s timeout
+        // inside the socket.write callback; if the socket dies between
+        // connect and write, the request promise never settles at all. An
+        // unsettled getDeviceInfo() would keep this bridge in
+        // activeScanBridges forever (the .finally in processAllDevices()
+        // never runs), silently wedging every future scan.
+        return await withTimeout(bridge.getDeviceInfo(), 60_000, 'device inventory fetch timed out')
       } catch (error) {
         lastError = error
         this.log.warn(`Device inventory fetch failed (attempt ${attempt + 1}/${delaysMs.length + 1}):`, error)
@@ -427,11 +678,36 @@ export class LutronCasetaLeap
       // prevents duplicate 'disconnected' and 'unsolicited' listeners from
       // accumulating on PicoRemote and OccupancySensor instances each time
       // the bridge re-announces or a deviceheard event fires.
-      const unwiredDevices = devices.filter(
-        d => !this.wiredDevices.has(this.api.hap.uuid.generate(d.SerialNumber.toString())),
-      )
+      const now = Date.now()
+      const unwiredDevices = devices.filter((d) => {
+        const uuid = this.api.hap.uuid.generate(d.SerialNumber.toString())
+        if (this.wiredDevices.has(uuid)) {
+          return false
+        }
+        // wiringDevices covers the gap the wire timeout opens: the timeout
+        // bounds the SCAN, not the wiring itself, so a slow-but-alive
+        // processDevice() can still be running when a follow-up scan starts.
+        // Wiring it a second time would create two PicoRemote instances and
+        // deliver every press twice. Claims older than the TTL belong to a
+        // wiring that can no longer complete; treat the device as retryable.
+        const claimedAt = this.wiringDevices.get(uuid)
+        return claimedAt === undefined || now - claimedAt >= WIRING_CLAIM_TTL_MS
+      })
       const results: PromiseSettledResult<string>[] = await Promise.allSettled(
-        unwiredDevices.map((device: DeviceDefinition) => this.processDevice(bridge, device)),
+        unwiredDevices.map((device: DeviceDefinition) => {
+          const uuid = this.api.hap.uuid.generate(device.SerialNumber.toString())
+          this.wiringDevices.set(uuid, now)
+          const wiring = this.processDevice(bridge, device)
+          // Release on the UNDERLYING promise, not the timeout wrapper, so
+          // the device stays claimed for as long as the wiring is genuinely
+          // in flight and becomes retryable the moment it truly settles.
+          wiring.catch(() => {}).finally(() => this.wiringDevices.delete(uuid))
+          return withTimeout(
+            wiring,
+            DEVICE_WIRE_TIMEOUT_MS,
+            `wiring ${device.FullyQualifiedName.join(' ')} timed out`,
+          )
+        }),
       )
       for (const result of results) {
         switch (result.status) {

--- a/src/Platform.Matter.ts
+++ b/src/Platform.Matter.ts
@@ -352,16 +352,30 @@ export class LutronCasetaLeapMatterPlatform extends LutronCasetaLeap {
 
     switch (result.kind) {
       case DeviceWireResultType.Error: {
+        // Mirror the HAP path's #207 cache-preservation rule: never unregister
+        // a cached accessory on a refresh-time failure. Error here is usually
+        // a transient bridge response during a rescan (and rescans now also
+        // run after every watchdog repair, so this path is hit during exactly
+        // the flaky windows when wiring is most likely to fail). Unregistering
+        // loses the user's Matter fabric placement, and a purged accessory
+        // does not come back until restart: the failed attempt already
+        // stamped accessory.parts, so the later successful wire computes no
+        // endpoint change and never re-registers.
         if (isFromCache) {
-          mApi.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
-          this.log.debug(`un-registered cached device ${fullName} (Matter) due to an error: ${result.reason}`)
+          this.log.warn(`Could not refresh device data for cached Matter device ${fullName}; leaving accessory registered: ${result.reason}`)
+          return Promise.resolve(`Leaving cached Matter accessory registered (refresh failed): ${fullName}`)
         }
         return Promise.reject(new Error(`Failed to wire device ${fullName}: ${result.reason}`))
       }
       case DeviceWireResultType.Skipped: {
+        // Same preservation rule for generic skips. Explicitly-excluded device
+        // types were already unregistered above, before this switch; anything
+        // else that reports Skipped for a cached accessory is a transient
+        // classification (filterPico responses missing AffectedZones, and
+        // similar) that can flip back on the next scan.
         if (isFromCache) {
-          this.log.debug(`un-registered cached device ${fullName} (Matter) because it was skipped`)
-          mApi.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
+          this.log.warn(`Skipping cached Matter device ${fullName}; leaving accessory registered: ${result.reason}`)
+          return Promise.resolve(`Leaving cached Matter accessory registered (skipped): ${fullName}`)
         }
         return Promise.resolve(`Skipped setting up device: ${result.reason}`)
       }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,7 +2,7 @@ import type { PlatformConfig } from 'homebridge'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { createPlatformProxy, normalizeConfig } from './utils.js'
+import { createPlatformProxy, normalizeConfig, withTimeout } from './utils.js'
 
 // ---------------------------------------------------------------------------
 // normalizeConfig
@@ -30,6 +30,74 @@ describe('normalizeConfig', () => {
   it('preserves arbitrary extra fields from raw config', () => {
     const cfg = normalizeConfig({ platform: 'LutronCasetaLeap', secrets: ['x'] } as any)
     expect((cfg as any).secrets).toEqual(['x'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withTimeout
+// ---------------------------------------------------------------------------
+
+describe('withTimeout', () => {
+  it('resolves with the wrapped value when the promise settles in time', async () => {
+    await expect(withTimeout(Promise.resolve(42), 1000, 'too slow')).resolves.toBe(42)
+  })
+
+  it('propagates the wrapped rejection unchanged', async () => {
+    await expect(withTimeout(Promise.reject(new Error('inner')), 1000, 'too slow')).rejects.toThrow('inner')
+  })
+
+  it('rejects with the timeout message when the promise never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      const hung = new Promise(() => { /* never settles */ })
+      const bounded = withTimeout(hung, 500, 'too slow')
+      const assertion = expect(bounded).rejects.toThrow('too slow')
+      await vi.advanceTimersByTimeAsync(500)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears the timer as soon as the wrapped promise settles', async () => {
+    // Promise.race would leave the 60s timer armed here, holding a handle on
+    // the event loop long after the work finished.
+    vi.useFakeTimers()
+    try {
+      await withTimeout(Promise.resolve('done'), 60_000, 'too slow')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a late rejection observed instead of leaking it', async () => {
+    // The #236 failure mode: the wrapped promise rejects AFTER the bound has
+    // already fired. Promise.race would leave that rejection unhandled, which
+    // is fatal to the Homebridge child bridge.
+    vi.useFakeTimers()
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => unhandled.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      let rejectLate: (e: Error) => void = () => {}
+      const slow = new Promise((_resolve, reject) => {
+        rejectLate = reject
+      })
+      const bounded = withTimeout(slow, 40, 'too slow')
+      const assertion = expect(bounded).rejects.toThrow('too slow')
+      await vi.advanceTimersByTimeAsync(40)
+      await assertion
+
+      rejectLate(new Error('late failure'))
+      await vi.advanceTimersByTimeAsync(100)
+      // Give the microtask queue a chance to surface an unhandled rejection.
+      await Promise.resolve()
+      expect(unhandled).toHaveLength(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,37 @@ export function normalizeConfig(raw?: PlatformConfig): LutronCasetaLeapPluginCon
 }
 
 /**
+ * Bounds a promise with a timeout.
+ *
+ * Deliberately not `Promise.race` against a bare reject-after-setTimeout
+ * promise, for two reasons this codebase has been bitten by:
+ *
+ *  - The timer is cleared as soon as the wrapped promise settles. Racing
+ *    leaves the timer armed for its full duration, so a fast call still pins
+ *    a handle on the event loop, and a 60s bound would keep the process
+ *    alive for 60s after the work finished.
+ *  - A rejection handler is attached to the wrapped promise unconditionally,
+ *    so a slow rejection arriving after the timeout has already fired stays
+ *    observed. Racing leaves that late rejection unhandled, which is the
+ *    pattern in lutron-leap's ping loop that crashed child bridges (#236).
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+/**
  * Creates a proxy class that instantiates the correct platform implementation
  * (HAP or Matter) at runtime based on the Homebridge API capabilities and the
  * user's configuration.  The proxy delegates the `configureAccessory` call


### PR DESCRIPTION
## Pull Request

### Description

The plugin can lose its connection to a Caseta bridge and never recover until Homebridge is restarted. This adds a per-bridge ping watchdog that detects a stale connection and repairs it, so recovery takes about three minutes instead of requiring a restart.

**Why it happens today.** A half-open socket (router reboot, Wi-Fi blip, bridge power cycle) emits no `close` event, so nothing notices. `lutron-leap` does detect it: `SmartBridge.startPingLoop()` pings every 5 minutes. But its failure handler is an explicit no-op ("I think the answer is: nothing"), and no TCP keepalive is set. That leaves two recovery paths, neither reliable:

- a socket `close` event, which a half-open connection never emits;
- an mDNS re-announce, which is best effort and can be blocked by VLANs, IGMP snooping, or AP multicast handling.

Before #236, the failed ping surfaced as an unhandled rejection that crashed the child bridge, and the restart happened to restore the connection. Suppressing that crash was correct, but it removed the accidental recovery without replacing it, so a dead connection now stays quietly dead.

**Design.** This follows `pylutron-caseta`, which Home Assistant's `lutron_caseta` integration uses and which does not exhibit this failure:

- Its `_ping()` runs on a **60s** interval (ours matches; `lutron-leap` uses 300s).
- Its failure handler calls `close()` to force a full rebuild. The ping is a liveness probe whose purpose is to trigger teardown, not a keepalive. A probe only helps if failure has teeth.
- Its `_monitor_once()` re-runs `_login()` on **every** connection, so subscriptions are re-established from a consumer-level registry rather than assumed to survive.

That last point shapes this PR, and it is the subtle part. **A successful ping is not proof the plugin is working.** `LeapClient.request()` awaits `connect()`, so a ping transparently opens a fresh socket, and `LeapClient._empty()` has already cleared `taggedSubscriptions`. A reachable bridge with no subscriptions answers pings while delivering no button presses at all. A naive ping-based watchdog would report green forever and actively mask the failure. So when a repair fails partway, the bridge is recorded as needing re-subscription and the next successful ping completes it.

### Related Issue

No open issue tracks this specific symptom. It is the same class of failure as the long-running #31 thread, and #129. Happy to link a fresh issue if you would prefer one for changelog purposes.

### Type of Change

- [x] 🐛 Bug fix (patch) - non-breaking change that fixes an issue

### Branch Targeting

Targeting `latest`, consistent with every PR merged since #207 (including #227, #228, #236). The template's `beta-{version}` checkbox appears to predate the current `copilot-instructions.md`, which now defers to `CLAUDE.md`, and no `beta-*` branch currently exists. Happy to retarget if that is wrong.

- [x] No `package.json` version bump included, since releases are cut separately via the release workflow. Say the word if you want one.

### Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] New tests have been added

`npm run lint` (clean at `--max-warnings=0`), `npx tsc --noEmit`, `npm run build`, and `npm test` all pass; the suite was run five consecutive times to check for fake-timer flakes (60/60 every run). 37 new unit tests, 60 total. `npm run changelog:sync` reports the pending section already in sync.

Coverage: the watchdog state machine (failure threshold, counter reset on recovery, a ping that never settles, revive re-entrancy, the reconfigure skip guard, shutdown), the platform wiring (watchdog created once per bridge, address recorded during an in-flight reconfigure, both reconfigure failure paths, standing down when an mDNS reconfigure starts during the pre-connect window, re-subscription after an interrupted repair, the in-flight wiring guard, bounded inventory fetch), the Matter cache-preservation rule, accessory identity across repeated repairs (no re-registration, no duplicates), and `withTimeout`'s timer cleanup and late-rejection behaviour.

### Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Code is well-commented, particularly in hard-to-understand areas
- [ ] Documentation has been updated (no user-facing config added, see below)

### Notes for Reviewers

**Deliberately not configurable.** The 60s interval and 3-strike threshold are constants rather than `config.schema.json` options. They are injectable through `ConnectionWatchdogOptions` if you would rather expose them, but I would lean toward not adding another knob for something that should just work. Easy to change if you disagree.

**Three library workarounds, each commented in place.** Flagging them explicitly since they are the parts most worth scrutiny:

1. `reconfigureBridge()` is pre-flighted with a bounded `connect()`. It is neither cancellable nor bounded: it drains the old client (destroying every subscription) *before* retrying connect up to 21 times, against a `tls.connect()` created with no timeout. Against a powered-off bridge it can sit for many minutes with `bridgeReconfigInProgress` true, which suppresses the watchdog *and* makes every mDNS announce a no-op. Connecting first means a repair that cannot reach the bridge fails fast and leaves the working connection untouched.
2. `bridgeReconfigInProgress` is reset by hand at both call sites. The library sets it with no `try/finally`, so a throw leaves it stuck true forever. Swallowing the error in the mDNS handler is deliberate (it has no caller, and an escaping rejection is the #236 crash), which is exactly why the manual reset is required.
3. The orphaned library ping interval is cleared before each reconfigure. `reconfigureBridge()` drops its reference without calling `clearInterval`, leaking a 5-minute timer per reconfigure. This reaches into a private field; `bridge.close()` is not usable instead because it re-emits `disconnected`, which would make every device re-subscribe against the client being discarded.

All three would be better fixed in `lutron-leap-js`. There is a related open PR there ([thenewwazoo/lutron-leap-js#38](https://github.com/thenewwazoo/lutron-leap-js/pull/38), "Reconnect when the keep-alive ping fails") that addresses the no-op catch, though it is narrower and that repo has been quiet since January. This PR is written to be correct regardless of whether the library changes.

**Concurrency guarantee worth reviewing closely:** a bridge recovering from a power cycle starts accepting TLS at the same moment it fires its mDNS announce, so the announce path and a watchdog repair can race. `reviveBridge()` re-checks `bridgeReconfigInProgress` after its bounded pre-connect and stands down if the announce path got there first; the mDNS path sets that flag synchronously and there are no awaits between the re-check and the reconfigure, so two reconfigures can never overlap. Without this, both would run, every button would be subscribed twice, and the doubled Press events would reset the press/release state machine, which reads as dead Picos.

**Matter platform: cache preservation now mirrors the HAP path.** The Matter `processDevice` override was still unregistering cached accessories on refresh-time Error and transient Skipped results, the pattern #207 fixed for HAP. Repair-triggered rescans run during exactly the flaky windows where transient wire failures are most likely, and a purged Matter accessory does not return until restart (the failed attempt already stamped `accessory.parts`, so the later successful wire computes no endpoint change and never re-registers). Cached accessories are now left registered in both modes; explicit config exclusions still unregister.

**Re-subscription bursts can no longer crash the child bridge.** `subscribeToButton()` discards the subscribe promise inside the library, so a failed re-subscribe after a reconnect was both invisible and fatal (an unhandled rejection the process-level policy rethrows). Both re-subscribe paths now observe their promises. The Pico path warns in the Homebridge log; the occupancy path logs on the library's debug channel, since the router singleton has no Homebridge logger.

**The in-flight wiring guard's claims expire.** The guard prevents a scan timeout from wiring a device twice, but a wiring stranded by `drain()` has had its resolver dropped and can never settle, so a claim released only on settlement would exclude that device from every future scan until restart. Claims therefore expire after three scan timeouts; expiry is safe because a wire hung that way has no remaining path to completion and can never race a later retry.

**Also fixed in passing:** `getDeviceInfo()` and per-device wiring are now bounded, because `request()` arms its 5s timeout *inside* the `socket.write` callback, so a request against a socket that dies between connect and write never settles, stranding the scan and leaving the bridge in `activeScanBridges` forever. An in-flight guard prevents a scan timeout from wiring the same device twice. Watchdogs stop on Homebridge shutdown, the TLS keylog stream is cached per bridge rather than leaked per client, and the debug log line that dumped the bridge private key and certificate now logs only that secrets are configured.
